### PR TITLE
Feature/520

### DIFF
--- a/@permobil/core/src/models/pushtracker.user.model.ts
+++ b/@permobil/core/src/models/pushtracker.user.model.ts
@@ -1,3 +1,46 @@
+export interface PushTrackerUserData {
+  /**
+   * Kinvey Data
+   */
+  _socialIdentity?: object;
+  username?: string;
+  email?: string;
+
+  /**
+   * Our data
+   */
+  first_name: string;
+  last_name: string;
+  gender: string;
+  dob: Date;
+  // weight and height in metric
+  weight: number; // kg
+  height: number; // cm
+  chair_type: string;
+  chair_make: string;
+  // (1) smartdrive with switch control only, (2) smartdrive with pushtracker, or (3) smartdrive with pushtracker e2
+  control_configuration: string;
+  phone: string;
+  accessToken: string;
+  profile_picture: string;
+  // data protection
+  has_agreed_to_user_agreement: boolean;
+  has_read_privacy_policy: boolean;
+  // activity goals
+  activity_goal_coast_time: number;
+  activity_goal_distance: number;
+  // unit preference
+  weight_unit_preference: string;
+  height_unit_preference: string;
+  distance_unit_preference: string;
+  // Display preferences
+  time_format_preference: string;
+  language_preference: string;
+  // serial number
+  smartdrive_serial_number: string;
+  pushtracker_serial_number: string;
+}
+
 export interface PushTrackerUser {
   readonly _id: string;
   readonly _acl: any;

--- a/apps/mobile/pushtracker/package.json
+++ b/apps/mobile/pushtracker/package.json
@@ -4,10 +4,10 @@
       "android": "com.permobil.pushtracker",
       "ios": "com.max-mobility.PushTracker"
     },
-    "tns-android": {
+    "tns-ios": {
       "version": "6.2.0"
     },
-    "tns-ios": {
+    "tns-android": {
       "version": "6.2.0"
     }
   },

--- a/apps/mobile/pushtracker/src/app/app.component.ts
+++ b/apps/mobile/pushtracker/src/app/app.component.ts
@@ -12,7 +12,7 @@ import { Sentry } from 'nativescript-sentry';
 import { AppURL, handleOpenURL } from 'nativescript-urlhandler';
 import { APP_LANGUAGES, APP_THEMES, STORAGE_KEYS } from './enums';
 import { LoggingService } from './services';
-import { applyTheme, APP_KEY, APP_SECRET, getFirstDayOfWeek, getJSONFromKinvey, YYYY_MM_DD } from './utils';
+import { applyTheme, APP_KEY, APP_SECRET, getFirstDayOfWeek, YYYY_MM_DD } from './utils';
 
 registerElement(
   'AnimatedCircle',
@@ -94,9 +94,6 @@ export class AppComponent implements OnInit {
     );
 
     application.on(application.resumeEvent, () => {
-      const weekStart = getFirstDayOfWeek(new Date());
-      this._loadWeeklyActivityFromKinvey(weekStart);
-      this._loadSmartDriveUsageFromKinvey(weekStart);
     });
 
     Kinvey.init({ appKey: `${APP_KEY}`, appSecret: `${APP_SECRET}` });
@@ -129,65 +126,5 @@ export class AppComponent implements OnInit {
       APP_THEMES.DEFAULT
     );
     applyTheme(CURRENT_THEME);
-  }
-
-  async _loadWeeklyActivityFromKinvey(weekStartDate: Date) {
-    this._logService.logBreadCrumb(
-      AppComponent.name,
-      'Loading WeeklyPushTrackerActivity from Kinvey'
-    );
-    const user = Kinvey.User.getActiveUser();
-    if (!user) return;
-    let result = [];
-    const date = YYYY_MM_DD(weekStartDate);
-    // Query Kinvey database for weekly pushtracker activity
-    const queryString = `?query={"_acl.creator":"${user._id}","date":"${date}"}&limit=1&sort={"_kmd.lmt":-1}`;
-    return getJSONFromKinvey(`WeeklyPushTrackerActivity${queryString}`)
-      .then(data => {
-        if (data && data.length) {
-          result = data[0];
-          appSettings.setString(
-            'PushTracker.WeeklyActivity.' + date,
-            JSON.stringify(result)
-          );
-          return Promise.resolve(true);
-        }
-        return Promise.resolve(true);
-      })
-      .catch(err => {
-        this._logService.logBreadCrumb(AppComponent.name, 'Failed to load weekly activity from kinvey');
-        // this._logService.logException(err);
-        return Promise.reject(false);
-      });
-  }
-
-  async _loadSmartDriveUsageFromKinvey(weekStartDate: Date) {
-    this._logService.logBreadCrumb(
-      AppComponent.name,
-      'Loading WeeklySmartDriveUsage from Kinvey'
-    );
-    const user = Kinvey.User.getActiveUser();
-    let result = [];
-    if (!user) return result;
-    const date = YYYY_MM_DD(weekStartDate);
-    // Query Kinvey database for weekly smartdrive usage
-    const queryString = `?query={"_acl.creator":"${user._id}","date":"${date}"}&limit=1&sort={"_kmd.lmt":-1}`;
-    return getJSONFromKinvey(`WeeklySmartDriveUsage${queryString}`)
-      .then(data => {
-        if (data && data.length) {
-          result = data[0];
-          appSettings.setString(
-            'SmartDrive.WeeklyUsage.' + date,
-            JSON.stringify(result)
-          );
-          return Promise.resolve(true);
-        }
-        return Promise.resolve(false);
-      })
-      .catch(err => {
-        this._logService.logBreadCrumb(AppComponent.name, 'Failed to load weekly smartdrive usage from kinvey');
-        // this._logService.logException(err);
-        return Promise.reject(false);
-      });
   }
 }

--- a/apps/mobile/pushtracker/src/app/assets/i18n/en.json
+++ b/apps/mobile/pushtracker/src/app/assets/i18n/en.json
@@ -465,7 +465,7 @@
 		"last-name": "last name",
     "network-error": {
       "title": "Network Error",
-      "message": "Unable to connect to server, please make sure your phone has an internet connection."
+      "message": "Unable to connect to server, please make sure your device has an internet connection."
     },
 		"ok": "OK",
 		"per-day": "per day",

--- a/apps/mobile/pushtracker/src/app/assets/i18n/en.json
+++ b/apps/mobile/pushtracker/src/app/assets/i18n/en.json
@@ -463,6 +463,10 @@
 			"prefer-not-to-say": "Prefer not to say"
 		},
 		"last-name": "last name",
+    "network-error": {
+      "title": "Network Error",
+      "message": "Unable to connect to server, please make sure your phone has an internet connection."
+    },
 		"ok": "OK",
 		"per-day": "per day",
 		"pushtracker": "PushTracker",

--- a/apps/mobile/pushtracker/src/app/models/index.ts
+++ b/apps/mobile/pushtracker/src/app/models/index.ts
@@ -2,3 +2,4 @@ export * from './device-base.model';
 export * from './pairing.model';
 export * from './pushtracker.model';
 export * from './smartdrive.model';
+export * from './pushtracker-user.model';

--- a/apps/mobile/pushtracker/src/app/models/pushtracker-user.model.ts
+++ b/apps/mobile/pushtracker/src/app/models/pushtracker-user.model.ts
@@ -2,5 +2,5 @@ import { PushTrackerUserData } from '@permobil/core';
 import { User as KinveyUser } from 'kinvey-nativescript-sdk';
 
 export class PushTrackerUser extends KinveyUser {
-  data: PushTrackerUserData
+  data: PushTrackerUserData;
 }

--- a/apps/mobile/pushtracker/src/app/models/pushtracker-user.model.ts
+++ b/apps/mobile/pushtracker/src/app/models/pushtracker-user.model.ts
@@ -1,0 +1,6 @@
+import { PushTrackerUserData } from '@permobil/core';
+import { User as KinveyUser } from 'kinvey-nativescript-sdk';
+
+export class PushTrackerUser extends KinveyUser {
+  data: PushTrackerUserData
+}

--- a/apps/mobile/pushtracker/src/app/modules/activity/activity.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/activity/activity.component.ts
@@ -214,6 +214,17 @@ export class ActivityComponent implements OnInit {
 
   async refreshPlots(args) {
     const pullRefresh = args.object;
+
+    // actually synchronize with the server
+    try {
+      await this._activityService.refreshWeekly();
+    } catch (err) {
+    }
+    try {
+      await this._usageService.refreshWeekly();
+    } catch (err) {
+    }
+
     this.onSelectedIndexChanged({
       object: { selectedIndex: this.currentTab },
       options: { forcePullFromDatabase: true }

--- a/apps/mobile/pushtracker/src/app/modules/activity/activity.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/activity/activity.component.ts
@@ -12,6 +12,7 @@ import {
 import * as appSettings from '@nativescript/core/application-settings';
 import { layout } from '@nativescript/core/utils/utils';
 import { TranslateService } from '@ngx-translate/core';
+import { Query as KinveyQuery } from 'kinvey-nativescript-sdk';
 import { PushTrackerUser } from '@permobil/core';
 import { differenceInCalendarDays } from 'date-fns';
 import debounce from 'lodash/debounce';
@@ -29,12 +30,11 @@ import {
   STORAGE_KEYS
 } from '../../enums';
 import { DeviceBase } from '../../models';
-import { LoggingService } from '../../services';
+import { ActivityService, SmartDriveUsageService, LoggingService } from '../../services';
 import {
   areDatesSame,
   convertToMilesIfUnitPreferenceIsMiles,
   getFirstDayOfWeek,
-  getJSONFromKinvey,
   YYYY_MM_DD
 } from '../../utils';
 
@@ -142,6 +142,8 @@ export class ActivityComponent implements OnInit {
   private _dailyUsageFromKinvey: any;
 
   constructor(
+    private _activityService: ActivityService,
+    private _usageService: SmartDriveUsageService,
     private _logService: LoggingService,
     private _translateService: TranslateService,
     private _params: ModalDialogParams
@@ -555,8 +557,8 @@ export class ActivityComponent implements OnInit {
                     convertToMilesIfUnitPreferenceIsMiles(
                       DeviceBase.caseTicksToKilometers(
                         this._dailyUsageFromKinvey.distance_smartdrive_coast -
-                          this._dailyUsageFromKinvey
-                            .distance_smartdrive_coast_start
+                        this._dailyUsageFromKinvey
+                          .distance_smartdrive_coast_start
                       ),
                       this.user.data.distance_unit_preference
                     ) || 0
@@ -621,8 +623,11 @@ export class ActivityComponent implements OnInit {
 
     const date = YYYY_MM_DD(weekStartDate);
 
-    const queryString = `?query={"_acl.creator":"${this.user._id}","date":"${date}"}&limit=1&sort={"_kmd.lmt":-1}`;
-    return getJSONFromKinvey(`WeeklyPushTrackerActivity${queryString}`)
+    const query = new KinveyQuery();
+    query.equalTo('date', date);
+    query.descending('_kmd.lmt');
+    query.limit = 1;
+    return this._activityService.getWeeklyActivityWithQuery(query)
       .then(data => {
         if (data && data.length) {
           result = data[0];
@@ -657,8 +662,11 @@ export class ActivityComponent implements OnInit {
 
     const date = YYYY_MM_DD(weekStartDate);
 
-    const queryString = `?query={"_acl.creator":"${this.user._id}","date":"${date}"}&limit=1&sort={"_kmd.lmt":-1}`;
-    return getJSONFromKinvey(`WeeklySmartDriveUsage${queryString}`)
+    const query = new KinveyQuery();
+    query.equalTo('date', date);
+    query.descending('_kmd.lmt');
+    query.limit = 1;
+    return this._usageService.getWeeklyActivityWithQuery(query)
       .then(data => {
         if (data && data.length) {
           result = data[0];
@@ -795,7 +803,7 @@ export class ActivityComponent implements OnInit {
               convertToMilesIfUnitPreferenceIsMiles(
                 DeviceBase.caseTicksToKilometers(
                   cache.weeklyActivity.distance_smartdrive_coast -
-                    cache.weeklyActivity.distance_smartdrive_coast_start
+                  cache.weeklyActivity.distance_smartdrive_coast_start
                 ),
                 this.user.data.distance_unit_preference
               ) || 0
@@ -868,7 +876,7 @@ export class ActivityComponent implements OnInit {
               convertToMilesIfUnitPreferenceIsMiles(
                 DeviceBase.caseTicksToKilometers(
                   activity.distance_smartdrive_coast -
-                    activity.distance_smartdrive_coast_start
+                  activity.distance_smartdrive_coast_start
                 ),
                 this.user.data.distance_unit_preference
               ) || 0
@@ -1104,7 +1112,7 @@ export class ActivityComponent implements OnInit {
               convertToMilesIfUnitPreferenceIsMiles(
                 DeviceBase.caseTicksToKilometers(
                   activity.distance_smartdrive_coast -
-                    activity.distance_smartdrive_coast_start
+                  activity.distance_smartdrive_coast_start
                 ),
                 this.user.data.distance_unit_preference
               ) || 0
@@ -1157,7 +1165,7 @@ export class ActivityComponent implements OnInit {
               convertToMilesIfUnitPreferenceIsMiles(
                 DeviceBase.motorTicksToKilometers(
                   dailyActivity.distance_smartdrive_drive -
-                    dailyActivity.distance_smartdrive_drive_start
+                  dailyActivity.distance_smartdrive_drive_start
                 ),
                 this.user.data.distance_unit_preference
               ) || 0;
@@ -1166,7 +1174,7 @@ export class ActivityComponent implements OnInit {
               convertToMilesIfUnitPreferenceIsMiles(
                 DeviceBase.caseTicksToKilometers(
                   dailyActivity.distance_smartdrive_coast -
-                    dailyActivity.distance_smartdrive_coast_start
+                  dailyActivity.distance_smartdrive_coast_start
                 ),
                 this.user.data.distance_unit_preference
               ) || 0;
@@ -1407,7 +1415,7 @@ export class ActivityComponent implements OnInit {
             convertToMilesIfUnitPreferenceIsMiles(
               DeviceBase.caseTicksToKilometers(
                 activity.distance_smartdrive_coast -
-                  activity.distance_smartdrive_coast_start
+                activity.distance_smartdrive_coast_start
               ),
               this.user.data.distance_unit_preference
             ) || 0
@@ -1453,7 +1461,7 @@ export class ActivityComponent implements OnInit {
           convertToMilesIfUnitPreferenceIsMiles(
             DeviceBase.caseTicksToKilometers(
               activity.distance_smartdrive_coast -
-                activity.distance_smartdrive_coast_start
+              activity.distance_smartdrive_coast_start
             ),
             this.user.data.distance_unit_preference
           ) || 0;
@@ -1512,7 +1520,7 @@ export class ActivityComponent implements OnInit {
               convertToMilesIfUnitPreferenceIsMiles(
                 DeviceBase.caseTicksToKilometers(
                   activity.distance_smartdrive_coast -
-                    activity.distance_smartdrive_coast_start
+                  activity.distance_smartdrive_coast_start
                 ),
                 this.user.data.distance_unit_preference
               ) || 0
@@ -1529,7 +1537,7 @@ export class ActivityComponent implements OnInit {
             convertToMilesIfUnitPreferenceIsMiles(
               DeviceBase.caseTicksToKilometers(
                 cache.weeklyActivity.distance_smartdrive_coast -
-                  cache.weeklyActivity.distance_smartdrive_coast_start
+                cache.weeklyActivity.distance_smartdrive_coast_start
               ),
               this.user.data.distance_unit_preference
             ) || 0
@@ -1605,7 +1613,7 @@ export class ActivityComponent implements OnInit {
             convertToMilesIfUnitPreferenceIsMiles(
               DeviceBase.caseTicksToKilometers(
                 activity.distance_smartdrive_coast -
-                  activity.distance_smartdrive_coast_start
+                activity.distance_smartdrive_coast_start
               ),
               this.user.data.distance_unit_preference
             ) || 0;
@@ -1633,7 +1641,7 @@ export class ActivityComponent implements OnInit {
           convertToMilesIfUnitPreferenceIsMiles(
             DeviceBase.caseTicksToKilometers(
               cache.weeklyActivity.distance_smartdrive_coast -
-                cache.weeklyActivity.distance_smartdrive_coast_start
+              cache.weeklyActivity.distance_smartdrive_coast_start
             ),
             this.user.data.distance_unit_preference
           ) || 0;

--- a/apps/mobile/pushtracker/src/app/modules/configuration/configuration.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/configuration/configuration.component.ts
@@ -2,10 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Page } from '@nativescript/core';
 import * as appSettings from '@nativescript/core/application-settings';
-import { PushTrackerUser } from '@permobil/core';
 import { User as KinveyUser } from 'kinvey-nativescript-sdk';
 import { CONFIGURATIONS } from '../../enums';
-import { PushTrackerUserService } from '../../services';
+import { PushTrackerUser } from '../../models';
 
 @Component({
   selector: 'configuration',
@@ -18,16 +17,13 @@ export class ConfigurationComponent implements OnInit {
 
   constructor(
     private _router: Router,
-    private userService: PushTrackerUserService,
     private _page: Page
   ) {
     this._page.actionBarHidden = true;
   }
 
   ngOnInit() {
-    this.userService.user.subscribe(user => {
-      this._user = user;
-    });
+    this._user = KinveyUser.getActiveUser() as PushTrackerUser;
   }
 
   onConfigurationSelection(_, selection) {
@@ -38,7 +34,9 @@ export class ConfigurationComponent implements OnInit {
       });
       if (this._user) {
         this._user.data.control_configuration = selection;
-        this.userService.updateDataProperty('control_configuration', selection);
+        this._user.update({
+          control_configuration: selection
+        })
         appSettings.setString('Kinvey.User', JSON.stringify(this._user));
       }
     }

--- a/apps/mobile/pushtracker/src/app/modules/configuration/configuration.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/configuration/configuration.component.ts
@@ -26,19 +26,12 @@ export class ConfigurationComponent implements OnInit {
     this._user = KinveyUser.getActiveUser() as PushTrackerUser;
   }
 
-  onConfigurationSelection(_, selection) {
-    const loggedInUser = KinveyUser.getActiveUser();
-    if (loggedInUser) {
-      KinveyUser.update({
+  async onConfigurationSelection(_, selection) {
+    if (this._user) {
+      await this._user.update({
         control_configuration: selection
       });
-      if (this._user) {
-        this._user.data.control_configuration = selection;
-        this._user.update({
-          control_configuration: selection
-        });
-        appSettings.setString('Kinvey.User', JSON.stringify(this._user));
-      }
+      appSettings.setString('Kinvey.User', JSON.stringify(this._user));
     }
     if (selection === CONFIGURATIONS.SWITCHCONTROL_WITH_SMARTDRIVE) {
       this._router.navigate(['/tabs/default']);

--- a/apps/mobile/pushtracker/src/app/modules/configuration/configuration.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/configuration/configuration.component.ts
@@ -36,7 +36,7 @@ export class ConfigurationComponent implements OnInit {
         this._user.data.control_configuration = selection;
         this._user.update({
           control_configuration: selection
-        })
+        });
         appSettings.setString('Kinvey.User', JSON.stringify(this._user));
       }
     }

--- a/apps/mobile/pushtracker/src/app/modules/device-setup/device-setup.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/device-setup/device-setup.component.ts
@@ -7,13 +7,12 @@ import * as application from '@nativescript/core/application';
 import * as appSettings from '@nativescript/core/application-settings';
 import { action, alert } from '@nativescript/core/ui/dialogs';
 import { TranslateService } from '@ngx-translate/core';
-import { PushTrackerUser } from '@permobil/core';
 import { User as KinveyUser } from 'kinvey-nativescript-sdk';
 import { hasPermission, requestPermissions } from 'nativescript-permissions';
 import { ToastDuration, Toasty } from 'nativescript-toasty';
 import { APP_THEMES, CONFIGURATIONS, STORAGE_KEYS } from '../../enums';
-import { PushTracker } from '../../models';
-import { BluetoothService, LoggingCategory, LoggingService, PushTrackerUserService } from '../../services';
+import { PushTracker, PushTrackerUser } from '../../models';
+import { BluetoothService, LoggingCategory, LoggingService } from '../../services';
 
 // TODO: activity indicator for E2 on ios (during scanning /
 // connection / etc.)
@@ -55,7 +54,6 @@ export class DeviceSetupComponent implements OnInit {
   private CAPABILITY_PHONE_APP: string = 'permobil_pushtracker_phone_app';
   constructor(
     private _router: Router,
-    private _userService: PushTrackerUserService,
     private _bluetoothService: BluetoothService,
     private _translateService: TranslateService,
     private _logService: LoggingService,
@@ -70,78 +68,76 @@ export class DeviceSetupComponent implements OnInit {
     );
   }
 
-  ngOnInit() {
-    this._userService.user.subscribe(async user => {
-      this.user = user;
+  async ngOnInit() {
+    this.user = KinveyUser.getActiveUser() as PushTrackerUser;
 
-      if (
-        !this.slide &&
-        this.user &&
-        this.user.data.control_configuration ===
-          CONFIGURATIONS.PUSHTRACKER_WITH_SMARTDRIVE
-      ) {
-        // OG PushTracker configuration
-        this.slide = this._translateService.instant(
-          'device-setup.pushtracker-with-smartdrive'
+    if (
+      !this.slide &&
+      this.user &&
+      this.user.data.control_configuration ===
+      CONFIGURATIONS.PUSHTRACKER_WITH_SMARTDRIVE
+    ) {
+      // OG PushTracker configuration
+      this.slide = this._translateService.instant(
+        'device-setup.pushtracker-with-smartdrive'
+      );
+
+      // Check for already connected PushTrackers
+      this.onPushTrackerConnected();
+
+      if (!this.pushTracker && !this.bluetoothAdvertised) {
+        this._logService.logBreadCrumb(
+          DeviceSetupComponent.name,
+          'Asking for Bluetooth Permission'
         );
-
-        // Check for already connected PushTrackers
-        this.onPushTrackerConnected();
-
-        if (!this.pushTracker && !this.bluetoothAdvertised) {
-          this._logService.logBreadCrumb(
-            DeviceSetupComponent.name,
-            'Asking for Bluetooth Permission'
-          );
-          this._askForPermissions()
-            .then(() => {
-              if (!this._bluetoothService.advertising) {
-                this._logService.logBreadCrumb(
-                  DeviceSetupComponent.name,
-                  'Starting Bluetooth'
-                );
-                // start the bluetooth service
-                return this._bluetoothService.advertise();
-              }
-            })
-            .catch(err => {
-              this._logService.logException(err);
-            });
-          this.bluetoothAdvertised = true;
-        }
-
-        this._bluetoothService.on(
-          BluetoothService.pushtracker_connected,
-          this.onPushTrackerConnected,
-          this
-        );
-
-        this._bluetoothService.on(
-          BluetoothService.pushtracker_disconnected,
-          this.onPushTrackerDisconnected,
-          this
-        );
+        this._askForPermissions()
+          .then(() => {
+            if (!this._bluetoothService.advertising) {
+              this._logService.logBreadCrumb(
+                DeviceSetupComponent.name,
+                'Starting Bluetooth'
+              );
+              // start the bluetooth service
+              return this._bluetoothService.advertise();
+            }
+          })
+          .catch(err => {
+            this._logService.logException(err);
+          });
+        this.bluetoothAdvertised = true;
       }
 
-      if (
-        !this.slide &&
-        this.user &&
-        this.user.data.control_configuration ===
-          CONFIGURATIONS.PUSHTRACKER_E2_WITH_SMARTDRIVE
-      ) {
-        // PushTracker E2/ WearOS configuration
-        this.slide = this._translateService.instant(
-          'device-setup.pushtracker-e2-with-smartdrive'
-        );
-        try {
-          await WearOsComms.initPhone();
-        } catch (err) {
-          console.error('error initializing phone:', err);
-        }
-        // start looking for E2
-        this._onPushTrackerE2();
+      this._bluetoothService.on(
+        BluetoothService.pushtracker_connected,
+        this.onPushTrackerConnected,
+        this
+      );
+
+      this._bluetoothService.on(
+        BluetoothService.pushtracker_disconnected,
+        this.onPushTrackerDisconnected,
+        this
+      );
+    }
+
+    if (
+      !this.slide &&
+      this.user &&
+      this.user.data.control_configuration ===
+      CONFIGURATIONS.PUSHTRACKER_E2_WITH_SMARTDRIVE
+    ) {
+      // PushTracker E2/ WearOS configuration
+      this.slide = this._translateService.instant(
+        'device-setup.pushtracker-e2-with-smartdrive'
+      );
+      try {
+        await WearOsComms.initPhone();
+      } catch (err) {
+        console.error('error initializing phone:', err);
       }
-    });
+      // start looking for E2
+      this._onPushTrackerE2();
+    }
   }
 
   isAndroid(): boolean {
@@ -197,8 +193,8 @@ export class DeviceSetupComponent implements OnInit {
       const reasoning = {
         [android.Manifest.permission
           .ACCESS_COARSE_LOCATION]: this._translateService.instant(
-          'permissions-reasons.coarse-location'
-        )
+            'permissions-reasons.coarse-location'
+          )
       };
       neededPermissions.map(r => {
         reasons.push(reasoning[r]);
@@ -210,7 +206,7 @@ export class DeviceSetupComponent implements OnInit {
           okButtonText: this._translateService.instant('general.ok')
         });
         try {
-          await requestPermissions(neededPermissions, () => {});
+          await requestPermissions(neededPermissions, () => { });
           return true;
         } catch (permissionsObj) {
           const hasBlePermission =

--- a/apps/mobile/pushtracker/src/app/modules/device-setup/device-setup.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/device-setup/device-setup.component.ts
@@ -70,7 +70,6 @@ export class DeviceSetupComponent implements OnInit {
 
   async ngOnInit() {
     this.user = KinveyUser.getActiveUser() as PushTrackerUser;
-
     if (
       !this.slide &&
       this.user &&
@@ -515,7 +514,6 @@ export class DeviceSetupComponent implements OnInit {
       this._translateService.instant('device-setup.e2.connecting') + `${name}`;
     const didConnect = await this._connectCompanion();
     if (didConnect) {
-      console.log('didConnect', didConnect);
       this.statusMessage =
         this._translateService.instant(
           'device-setup.e2.sending-authorization'

--- a/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
@@ -13,7 +13,7 @@ import { ActivityComponent } from '..';
 import { APP_THEMES, CONFIGURATIONS, DISTANCE_UNITS, STORAGE_KEYS } from '../../enums';
 import { DeviceBase } from '../../models';
 import { ActivityService, SmartDriveUsageService, LoggingService, PushTrackerUserService } from '../../services';
-import { convertToMilesIfUnitPreferenceIsMiles, getFirstDayOfWeek, getJSONFromKinvey, getUserDataFromKinvey, milesToKilometers, YYYY_MM_DD } from '../../utils';
+import { convertToMilesIfUnitPreferenceIsMiles, getFirstDayOfWeek, getUserDataFromKinvey, milesToKilometers, YYYY_MM_DD } from '../../utils';
 
 @Component({
   selector: 'home-tab',

--- a/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
@@ -383,7 +383,7 @@ export class HomeTabComponent {
       }
     }
 
-    this._usageService.getWeeklyActivity(date, 1);
+    await this._usageService.getWeeklyActivity(date, 1);
 
     const queryString = `?query={"_acl.creator":"${this.user._id}","date":"${date}"}&limit=1&sort={"_kmd.lmt":-1}`;
     return getJSONFromKinvey(`WeeklySmartDriveUsage${queryString}`)
@@ -501,7 +501,7 @@ export class HomeTabComponent {
     if (!this.user) return Promise.resolve(result);
 
     // don't want to filter by date, just give the latest data available
-    this._usageService.getWeeklyActivity(null, 1);
+    await this._usageService.getWeeklyActivity(null, 1);
 
     const queryString = `?query={"_acl.creator":"${this.user._id}"}&limit=1&sort={"_kmd.lmt":-1}`;
     return getJSONFromKinvey(`WeeklySmartDriveUsage${queryString}`)
@@ -547,7 +547,7 @@ export class HomeTabComponent {
     let result = {} as any;
     if (!this.user) return result;
 
-    this._activityService.getWeeklyActivity(null, 1);
+    await this._activityService.getWeeklyActivity(null, 1);
 
     const queryString = `?query={"_acl.creator":"${this.user._id}"}&limit=1&sort={"_kmd.lmt":-1}`;
     return getJSONFromKinvey(`WeeklyPushTrackerActivity${queryString}`)
@@ -617,7 +617,7 @@ export class HomeTabComponent {
       }
     }
 
-    this._activityService.getWeeklyActivity(date, 1);
+    await this._activityService.getWeeklyActivity(date, 1);
 
     const queryString = `?query={"_acl.creator":"${this.user._id}","date":"${date}"}&limit=1&sort={"_kmd.lmt":-1}`;
     return getJSONFromKinvey(`WeeklyPushTrackerActivity${queryString}`)

--- a/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
@@ -249,6 +249,16 @@ export class HomeTabComponent {
       const gotUser = await this.refreshUserFromKinvey();
       if (!gotUser) return;
 
+      // actually synchronize with the server
+      try {
+        await this._activityService.refreshWeekly();
+      } catch (err) {
+      }
+      try {
+        await this._usageService.refreshWeekly();
+      } catch (err) {
+      }
+
       // The user might come back and refresh the next day, just keeping
       // the app running - Update currentDayInView and weekStart to
       // account for this

--- a/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
@@ -383,10 +383,7 @@ export class HomeTabComponent {
       }
     }
 
-    await this._usageService.getWeeklyActivity(date, 1);
-
-    const queryString = `?query={"_acl.creator":"${this.user._id}","date":"${date}"}&limit=1&sort={"_kmd.lmt":-1}`;
-    return getJSONFromKinvey(`WeeklySmartDriveUsage${queryString}`)
+    return this._usageService.getWeeklyActivity(date, 1)
       .then(data => {
         if (data && data.length) {
           result = data[0];
@@ -501,10 +498,7 @@ export class HomeTabComponent {
     if (!this.user) return Promise.resolve(result);
 
     // don't want to filter by date, just give the latest data available
-    await this._usageService.getWeeklyActivity(null, 1);
-
-    const queryString = `?query={"_acl.creator":"${this.user._id}"}&limit=1&sort={"_kmd.lmt":-1}`;
-    return getJSONFromKinvey(`WeeklySmartDriveUsage${queryString}`)
+    return this._usageService.getWeeklyActivity(null, 1)
       .then(data => {
         if (data && data.length) {
           result = data[0];
@@ -518,7 +512,7 @@ export class HomeTabComponent {
         }
         this._logService.logBreadCrumb(
           HomeTabComponent.name,
-          '' + 'No WeeklySmartDriveUsage data available for this week'
+          '' + 'No WeeklySmartDriveUsage data available at all!'
         );
         // There's no data for this week
         // Reset weekly usage object
@@ -547,10 +541,7 @@ export class HomeTabComponent {
     let result = {} as any;
     if (!this.user) return result;
 
-    await this._activityService.getWeeklyActivity(null, 1);
-
-    const queryString = `?query={"_acl.creator":"${this.user._id}"}&limit=1&sort={"_kmd.lmt":-1}`;
-    return getJSONFromKinvey(`WeeklyPushTrackerActivity${queryString}`)
+    return this._activityService.getWeeklyActivity(null, 1)
       .then(data => {
         if (data && data.length) {
           result = data[0];
@@ -617,10 +608,7 @@ export class HomeTabComponent {
       }
     }
 
-    await this._activityService.getWeeklyActivity(date, 1);
-
-    const queryString = `?query={"_acl.creator":"${this.user._id}","date":"${date}"}&limit=1&sort={"_kmd.lmt":-1}`;
-    return getJSONFromKinvey(`WeeklyPushTrackerActivity${queryString}`)
+    return this._activityService.getWeeklyActivity(date, 1)
       .then(data => {
         if (data && data.length) {
           result = data[0];

--- a/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
@@ -223,6 +223,12 @@ export class HomeTabComponent {
   async refreshUserFromKinvey() {
     try {
       const kinveyUser = KinveyUser.getActiveUser();
+      try {
+        await kinveyUser.me();
+      } catch (err) {
+        this._logService.logBreadCrumb(HomeTabComponent.name,
+          'Failed to refresh user from kinvey');
+      }
       this.parseUser(kinveyUser);
       return true;
     } catch (err) {

--- a/apps/mobile/pushtracker/src/app/modules/journey-tab/journey-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/journey-tab/journey-tab.component.ts
@@ -85,7 +85,7 @@ export class JourneyTabComponent {
       .then(() => {
         this.savedTimeFormat =
           this.user.data.time_format_preference || TIME_FORMAT.AM_PM;
-        this.initJourneyItems()
+        this._refresh()
           .then(() => {
             this._firstLoad = false;
           })

--- a/apps/mobile/pushtracker/src/app/modules/journey-tab/journey-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/journey-tab/journey-tab.component.ts
@@ -118,25 +118,6 @@ export class JourneyTabComponent {
     this._logService.logBreadCrumb(JourneyTabComponent.name, 'Unloaded');
   }
 
-  async initJourneyItems() {
-    this._loadDataForDate(this._weekStart, true)
-      .then(result => {
-        this.journeyItems = result;
-        if (result.length === 0) {
-          // force loading of more data if we have none on iOS
-          return this.onLoadMoreItems();
-        }
-      })
-      .then(result => {
-        this.journeyItemsLoaded = true;
-      })
-      .catch(err => {
-        this._logService.logBreadCrumb(JourneyTabComponent.name, 'Failed to load data fror data when init journey items');
-        // this._logService.logException(err);
-        this.journeyItemsLoaded = true;
-      });
-  }
-
   onRefreshTap() {
     this._logService.logBreadCrumb(JourneyTabComponent.name, 'Refresh tapped');
     this.debouncedRefresh();
@@ -156,7 +137,7 @@ export class JourneyTabComponent {
         this.showLoadingIndicator = false;
       })
       .catch(err => {
-        this._logService.logBreadCrumb(JourneyTabComponent.name, 'Failed to load data for date in onLoadMoreItems');
+        this._logService.logBreadCrumb(JourneyTabComponent.name, 'Failed to load data for date in onLoadMoreItems' + err);
         // this._logService.logException(err);
       });
   }
@@ -233,7 +214,7 @@ export class JourneyTabComponent {
             this.journeyItemsLoaded = true;
           })
           .catch(err => {
-            this._logService.logBreadCrumb(JourneyTabComponent.name, 'Failed to load data for date when refreshing user');
+            this._logService.logBreadCrumb(JourneyTabComponent.name, 'Failed to load data for date when refreshing user' + err);
             // this._logService.logException(err);
             this.journeyItemsLoaded = true;
           });
@@ -262,7 +243,7 @@ export class JourneyTabComponent {
                 });
             })
             .catch(err => {
-              this._logService.logBreadCrumb(JourneyTabComponent.name, 'Failed to load weekly smartdrive usage');
+              this._logService.logBreadCrumb(JourneyTabComponent.name, 'Failed to load weekly smartdrive usage' + err);
               // this._logService.logException(err);
             });
         } else {
@@ -721,17 +702,7 @@ export class JourneyTabComponent {
           for (const i in this._weeklyUsageFromKinvey.days) {
             if (areDatesSame(this._weekStart, date)) {
               const index = getDayOfWeek(new Date());
-              const firstDayOfCurrentWeek = this._weeklyUsageFromKinvey.days[0];
-              if (
-                firstDayOfCurrentWeek &&
-                firstDayOfCurrentWeek.date &&
-                areDatesSame(
-                  this._weekStart,
-                  new Date(firstDayOfCurrentWeek.date)
-                )
-              ) {
-                this.todayUsage = this._weeklyUsageFromKinvey.days[index];
-              }
+              this.todayUsage = this._weeklyUsageFromKinvey.days[index];
             }
 
             const dailyUsage = this._weeklyUsageFromKinvey.days[i];
@@ -803,7 +774,7 @@ export class JourneyTabComponent {
         return didLoad;
       })
       .catch(err => {
-        this._logService.logBreadCrumb(JourneyTabComponent.name, 'Failed to load weekly smartdrive usage from kinvey');
+        this._logService.logBreadCrumb(JourneyTabComponent.name, 'Failed to load weekly smartdrive usage from kinvey' + err);
         // this._logService.logException(err);
         return Promise.reject(false);
       });

--- a/apps/mobile/pushtracker/src/app/modules/journey-tab/journey-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/journey-tab/journey-tab.component.ts
@@ -199,7 +199,19 @@ export class JourneyTabComponent {
   private async _refresh() {
     this._logService.logBreadCrumb(JourneyTabComponent.name, 'Refreshing data');
     return this.refreshUserFromKinvey()
-      .then(() => {
+      .then(async () => {
+
+        // actually synchronize with the server
+        try {
+          await this._activityService.refreshWeekly();
+        } catch (err) {
+        }
+        try {
+          await this._usageService.refreshWeekly();
+        } catch (err) {
+        }
+
+        // now load the cached or refreshed data and display it
         this.noMorePushTrackerActivityDataAvailable = false;
         this.noMoreSmartDriveUsageDataAvailable = false;
         this.noMoreDataAvailable = false;

--- a/apps/mobile/pushtracker/src/app/modules/login/login.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/login/login.component.ts
@@ -6,14 +6,14 @@ import { device } from '@nativescript/core/platform';
 import { PercentLength } from '@nativescript/core/ui/styling/style-properties';
 import { TranslateService } from '@ngx-translate/core';
 import { LoadingIndicator } from '@nstudio/nativescript-loading-indicator';
-import { PushTrackerUser } from '@permobil/core';
 import { preventKeyboardFromShowing } from '@permobil/nativescript';
 import { validate } from 'email-validator';
 import * as Kinvey from 'kinvey-nativescript-sdk';
 import { LottieView } from 'nativescript-lottie';
 import { ToastDuration, ToastPosition, Toasty } from 'nativescript-toasty';
+import { PushTrackerUser } from '../../models';
 import { APP_THEMES, STORAGE_KEYS } from '../../enums';
-import { LoggingService, PushTrackerUserService } from '../../services';
+import { LoggingService } from '../../services';
 
 @Component({
   selector: 'login',
@@ -35,8 +35,7 @@ export class LoginComponent implements OnInit {
     private _logService: LoggingService,
     private _page: Page,
     private _translateService: TranslateService,
-    private _zone: NgZone,
-    private _userService: PushTrackerUserService
+    private _zone: NgZone
   ) {
     this._page.actionBarHidden = true;
     preventKeyboardFromShowing();
@@ -130,10 +129,6 @@ export class LoginComponent implements OnInit {
       this._loadingIndicator.hide();
 
       // Navigate to tabs home with clearHistory
-      // this._userService.reset();
-      this._userService.initializeUser(<PushTrackerUser>(
-        (<any>Kinvey.User.getActiveUser())
-      ));
       this._zone.run(() => {
         this._routerExtensions.navigate(['/tabs/default'], {
           clearHistory: true

--- a/apps/mobile/pushtracker/src/app/modules/profile-settings/profile-settings.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/profile-settings/profile-settings.component.ts
@@ -5,15 +5,15 @@ import { device } from '@nativescript/core/platform';
 import * as appSettings from '@nativescript/core/application-settings';
 import { alert } from '@nativescript/core/ui/dialogs';
 import { TranslateService } from '@ngx-translate/core';
-import { Device, PushTrackerUser } from '@permobil/core';
+import { Device } from '@permobil/core';
 import { User as KinveyUser } from 'kinvey-nativescript-sdk';
 import { getVersionNameSync, getVersionCodeSync } from 'nativescript-appversion';
 import debounce from 'lodash/debounce';
 import once from 'lodash/once';
 import { BottomSheetOptions, BottomSheetService } from 'nativescript-material-bottomsheet/angular';
 import { APP_LANGUAGES, APP_THEMES, CONFIGURATIONS, DISTANCE_UNITS, HEIGHT_UNITS, STORAGE_KEYS, TIME_FORMAT, WEIGHT_UNITS } from '../../enums';
-import { PushTracker, SmartDrive } from '../../models';
-import { BluetoothService, LoggingService, PushTrackerState, PushTrackerUserService, SettingsService, ThemeService, TranslationService } from '../../services';
+import { PushTracker, PushTrackerUser, SmartDrive } from '../../models';
+import { BluetoothService, LoggingService, PushTrackerState, SettingsService, ThemeService, TranslationService } from '../../services';
 import { applyTheme } from '../../utils';
 import { ListPickerSheetComponent, PushTrackerStatusButtonComponent, SliderSheetComponent } from '../shared/components';
 
@@ -70,7 +70,6 @@ export class ProfileSettingsComponent implements OnInit {
     private _translationService: TranslationService,
     private _translateService: TranslateService,
     private _page: Page,
-    private _userService: PushTrackerUserService,
     private _themeService: ThemeService,
     private _params: ModalDialogParams,
     private _bluetoothService: BluetoothService,
@@ -197,7 +196,7 @@ export class ProfileSettingsComponent implements OnInit {
   }
 
   getUser() {
-    this.user = this._params.context.user;
+    this.user = KinveyUser.getActiveUser() as PushTrackerUser;
     let defaultLanguage = 'English';
     Object.entries(APP_LANGUAGES).map(([key, value]) => {
       if (device.language.startsWith(value)) {
@@ -488,31 +487,19 @@ export class ProfileSettingsComponent implements OnInit {
     // save settings
     switch (this.activeSetting) {
       case 'height':
-        this._userService.updateDataProperty(
-          'height_unit_preference',
-          this.heightUnits[index]
-        );
-        KinveyUser.update({
+        this.user.update({
           height_unit_preference: this.heightUnits[index]
         });
         this.displayHeightUnit = this.heightUnitsTranslated[index];
         break;
       case 'weight':
-        this._userService.updateDataProperty(
-          'weight_unit_preference',
-          this.weightUnits[index]
-        );
-        KinveyUser.update({
+        this.user.update({
           weight_unit_preference: this.weightUnits[index]
         });
         this.displayWeightUnit = this.weightUnitsTranslated[index];
         break;
       case 'distance':
-        this._userService.updateDataProperty(
-          'distance_unit_preference',
-          this.distanceUnits[index]
-        );
-        KinveyUser.update({
+        this.user.update({
           distance_unit_preference: this.distanceUnits[index]
         });
         this.displayDistanceUnit = this.distanceUnitsTranslated[index];
@@ -526,11 +513,7 @@ export class ProfileSettingsComponent implements OnInit {
           Device.SwitchControlSettings.Mode.Options[index];
         break;
       case 'time format':
-        this._userService.updateDataProperty(
-          'time_format_preference',
-          this.timeFormats[index]
-        );
-        KinveyUser.update({
+        this.user.update({
           time_format_preference: this.timeFormats[index]
         });
         this.displayTimeFormat = this.timeFormatsTranslated[index];
@@ -548,11 +531,7 @@ export class ProfileSettingsComponent implements OnInit {
         break;
       case 'language':
         this.CURRENT_LANGUAGE = Object.keys(APP_LANGUAGES)[index];
-        this._userService.updateDataProperty(
-          'language_preference',
-          this.CURRENT_LANGUAGE
-        );
-        KinveyUser.update({ language_preference: this.CURRENT_LANGUAGE });
+        this.user.update({ language_preference: this.CURRENT_LANGUAGE });
         const language = APP_LANGUAGES[this.CURRENT_LANGUAGE];
         if (this._translateService.currentLang !== language) {
           this._translateService.reloadLang(language);

--- a/apps/mobile/pushtracker/src/app/modules/profile-settings/profile-settings.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/profile-settings/profile-settings.component.ts
@@ -13,7 +13,7 @@ import once from 'lodash/once';
 import { BottomSheetOptions, BottomSheetService } from 'nativescript-material-bottomsheet/angular';
 import { APP_LANGUAGES, APP_THEMES, CONFIGURATIONS, DISTANCE_UNITS, HEIGHT_UNITS, STORAGE_KEYS, TIME_FORMAT, WEIGHT_UNITS } from '../../enums';
 import { PushTracker, PushTrackerUser, SmartDrive } from '../../models';
-import { BluetoothService, LoggingService, PushTrackerState, SettingsService, ThemeService, TranslationService } from '../../services';
+import { BluetoothService, LoggingService, PushTrackerState, PushTrackerUserService, SettingsService, ThemeService, TranslationService } from '../../services';
 import { applyTheme } from '../../utils';
 import { ListPickerSheetComponent, PushTrackerStatusButtonComponent, SliderSheetComponent } from '../shared/components';
 
@@ -66,6 +66,7 @@ export class ProfileSettingsComponent implements OnInit {
 
   constructor(
     public settingsService: SettingsService,
+    private _userService: PushTrackerUserService,
     private _logService: LoggingService,
     private _translationService: TranslationService,
     private _translateService: TranslateService,
@@ -483,26 +484,67 @@ export class ProfileSettingsComponent implements OnInit {
     });
   }
 
+  private async updateUser(update: any) {
+    let didUpdate = false;
+    try {
+      await this.user.update(update);
+      didUpdate = true;
+    } catch (err) {
+      this._logService.logBreadCrumb(
+        ProfileSettingsComponent.name,
+        'Could not update the user - ' + err
+      );
+      setTimeout(() => {
+        alert({
+          title: this._translateService.instant('profile-tab.network-error.title'),
+          message: this._translateService.instant('profile-tab.network-error.message'),
+          okButtonText: this._translateService.instant('profile-tab.ok')
+        });
+      }, 1000);
+    }
+    appSettings.setString('Kinvey.User', JSON.stringify(this.user));
+    return didUpdate;
+  }
+
   private async _saveListPickerSettings(index) {
     // save settings
+    let didUpdate = false;
     switch (this.activeSetting) {
       case 'height':
-        this.user.update({
+        didUpdate = await this.updateUser({
           height_unit_preference: this.heightUnits[index]
         });
-        this.displayHeightUnit = this.heightUnitsTranslated[index];
+        if (didUpdate) {
+          this.displayHeightUnit = this.heightUnitsTranslated[index];
+          this._userService.emitEvent(
+            PushTrackerUserService.units_change_event,
+            { height_unit_preference: this.heightUnits[index] }
+          );
+        }
         break;
       case 'weight':
-        this.user.update({
+        didUpdate = await this.updateUser({
           weight_unit_preference: this.weightUnits[index]
         });
-        this.displayWeightUnit = this.weightUnitsTranslated[index];
+        if (didUpdate) {
+          this.displayWeightUnit = this.weightUnitsTranslated[index];
+          this._userService.emitEvent(
+            PushTrackerUserService.units_change_event,
+            { weight_unit_preference: this.weightUnits[index] }
+          );
+        }
         break;
       case 'distance':
-        this.user.update({
+        didUpdate = await this.updateUser({
           distance_unit_preference: this.distanceUnits[index]
         });
-        this.displayDistanceUnit = this.distanceUnitsTranslated[index];
+        if (didUpdate) {
+          this.displayDistanceUnit = this.distanceUnitsTranslated[index];
+          this._userService.emitEvent(
+            PushTrackerUserService.units_change_event,
+            { distance_unit_preference: this.distanceUnits[index] }
+          );
+        }
         break;
       case 'mode':
         this.settingsService.settings.controlMode =
@@ -513,10 +555,12 @@ export class ProfileSettingsComponent implements OnInit {
           Device.SwitchControlSettings.Mode.Options[index];
         break;
       case 'time format':
-        this.user.update({
+        didUpdate = await this.updateUser({
           time_format_preference: this.timeFormats[index]
         });
-        this.displayTimeFormat = this.timeFormatsTranslated[index];
+        if (didUpdate) {
+          this.displayTimeFormat = this.timeFormatsTranslated[index];
+        }
         break;
       case 'theme':
         this.CURRENT_THEME = Object.keys(APP_THEMES)[index];
@@ -530,22 +574,19 @@ export class ProfileSettingsComponent implements OnInit {
         }
         break;
       case 'language':
-        this.CURRENT_LANGUAGE = Object.keys(APP_LANGUAGES)[index];
-        this.user.update({ language_preference: this.CURRENT_LANGUAGE });
-        const language = APP_LANGUAGES[this.CURRENT_LANGUAGE];
-        if (this._translateService.currentLang !== language) {
-          this._translateService.reloadLang(language);
-          this._translateService.use(language);
+        const newLanguage = Object.keys(APP_LANGUAGES)[index];
+        didUpdate = await this.updateUser({ language_preference: newLanguage });
+        if (didUpdate) {
+          this.CURRENT_LANGUAGE = newLanguage;
+          const language = APP_LANGUAGES[this.CURRENT_LANGUAGE];
+          if (this._translateService.currentLang !== language) {
+            this._translateService.reloadLang(language);
+            this._translateService.use(language);
+          }
         }
         break;
     }
-    // Update local cache of this.user in appSettings
-    appSettings.setString('Kinvey.User', JSON.stringify(this.user));
     if (this.activeSetting !== 'theme') this._debouncedCommitSettingsFunction();
-    this._logService.logBreadCrumb(
-      ProfileSettingsComponent.name,
-      `User updated setting: ${this.activeSetting} to: ${index}`
-    );
   }
 
   private async _saveSliderSetting(newValue) {

--- a/apps/mobile/pushtracker/src/app/modules/profile-tab/profile-tab.component.html
+++ b/apps/mobile/pushtracker/src/app/modules/profile-tab/profile-tab.component.html
@@ -4,7 +4,7 @@
   <GridLayout row="0" rowSpan="3" col="0" rows="auto, *, auto" columns="*">
     // Mock ActionBar
     <MockActionBar row="0" [showBackNav]="false" [showSettingsBtn]="true" [showSupportBtn]="true" [user]="user">
-      <e2-status-button #e2StatusButton id="e2StatusButton" *ngIf="user?.data.control_configuration === CONFIGURATIONS.PUSHTRACKER_E2_WITH_SMARTDRIVE"></e2-status-button>
+      <e2-status-button *ngIf="user?.data.control_configuration === CONFIGURATIONS.PUSHTRACKER_E2_WITH_SMARTDRIVE"></e2-status-button>
     </MockActionBar>
 
     <ScrollView row="1" rowSpan="2" col="0" padding="10" height="100%" width="100%" iosOverflowSafeArea="false">

--- a/apps/mobile/pushtracker/src/app/modules/profile-tab/profile-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/profile-tab/profile-tab.component.ts
@@ -92,6 +92,13 @@ export class ProfileTabComponent {
       // Update the displayed control configuration icon on theme change
       this._initDisplayControlConfiguration();
     });
+
+    // register for units update events
+    this._userService.on(
+      PushTrackerUserService.units_change_event,
+      this.onUserUpdateUnits,
+      this
+    );
   }
 
   onProfileTabLoaded() {
@@ -1002,6 +1009,18 @@ export class ProfileTabComponent {
     // now actually update the rendering
     this.updateUserDisplay();
     return didUpdate;
+  }
+
+  private onUserUpdateUnits(args: any) {
+    const data = args.data;
+    Object.entries(data).map(([key, value]) => {
+      this._logService.logBreadCrumb(
+        ProfileTabComponent.name,
+        `Registered user changed units: ${key}: ${value}`
+      );
+      this.user.data[key] = value;
+    });
+    this.updateUserDisplay();
   }
 
   private updateUserDisplay() {

--- a/apps/mobile/pushtracker/src/app/modules/profile-tab/profile-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/profile-tab/profile-tab.component.ts
@@ -811,7 +811,7 @@ export class ProfileTabComponent {
     this._bottomSheet.show(ListPickerSheetComponent, options).subscribe(
       async result => {
         if (result && result.data) {
-          const newConfig = this.configurations[result.data.primaryIndex]
+          const newConfig = this.configurations[result.data.primaryIndex];
           if (this.user.data.control_configuration !== newConfig) {
             const didUpdate = await this.updateUser({
               control_configuration: newConfig

--- a/apps/mobile/pushtracker/src/app/modules/profile-tab/profile-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/profile-tab/profile-tab.component.ts
@@ -101,7 +101,7 @@ export class ProfileTabComponent {
     );
   }
 
-  onProfileTabLoaded() {
+  async onProfileTabLoaded() {
     this._logService.logBreadCrumb(ProfileTabComponent.name, 'Loaded');
     this._page.actionBarHidden = true;
     this.screenHeight = screen.mainScreen.heightDIPs;
@@ -140,6 +140,12 @@ export class ProfileTabComponent {
     // Do not sort any derived lists, e.g., this.chairMakesTranslated, here.
 
     this.user = KinveyUser.getActiveUser() as PushTrackerUser;
+    try {
+      await this.user.me();
+    } catch (err) {
+      this._logService.logBreadCrumb(ProfileTabComponent.name,
+        'Failed to refresh user from kinvey');
+    }
     this.updateUserDisplay();
   }
 

--- a/apps/mobile/pushtracker/src/app/modules/sign-up/sign-up.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/sign-up/sign-up.component.ts
@@ -27,9 +27,8 @@ import {
   CHAIR_TYPE,
   TIME_FORMAT
 } from '../../enums';
-import { LoggingService, PushTrackerUserService } from '../../services';
+import { LoggingService } from '../../services';
 import { PrivacyPolicyComponent } from '..';
-import { PushTrackerUser } from '@permobil/core';
 import * as Kinvey from 'kinvey-nativescript-sdk';
 import { APP_KEY, APP_SECRET } from '../../utils/kinvey-keys';
 
@@ -96,8 +95,7 @@ export class SignUpComponent implements OnInit {
     private _router: RouterExtensions,
     private _modalService: ModalDialogService,
     private _translateService: TranslateService,
-    private _vcRef: ViewContainerRef,
-    private _userService: PushTrackerUserService
+    private _vcRef: ViewContainerRef
   ) {
     preventKeyboardFromShowing();
 
@@ -277,9 +275,6 @@ export class SignUpComponent implements OnInit {
             .then(() => {
               // Kinvey SDK is working
               // Navigate to tabs home with clearHistory
-              this._userService.initializeUser(<PushTrackerUser>(
-                (<any>KinveyUser.getActiveUser())
-              ));
               this._router.navigate(['configuration'], {
                 clearHistory: true
               });

--- a/apps/mobile/pushtracker/src/app/modules/tabs/tabs.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/tabs/tabs.component.ts
@@ -69,6 +69,12 @@ export class TabsComponent {
       }
     );
 
+    // make sure to reset the data services when we load (in case the
+    // user has changed)
+    this._activityService.reset();
+    this._usageService.reset();
+    this._errorsService.reset();
+
     this._userService.user.subscribe(async user => {
       if (!user || !user.data) {
         // we should probably logout here since we don't have a valid

--- a/apps/mobile/pushtracker/src/app/modules/tabs/tabs.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/tabs/tabs.component.ts
@@ -70,7 +70,7 @@ export class TabsComponent {
     );
 
     this._userService.user.subscribe(async user => {
-      if (!user) {
+      if (!user || !user.data) {
         // we should probably logout here since we don't have a valid
         // user
         KinveyUser.logout();
@@ -94,6 +94,10 @@ export class TabsComponent {
       const config = this.user.data.control_configuration;
       // @ts-ignore
       if (!Object.values(CONFIGURATIONS).includes(config)) {
+        this._logService.logBreadCrumb(
+          TabsComponent.name,
+          `got user, but did not get valid configuration: ${config}, ${this.user}`
+        );
         // the user does not have a valid configuration - route to the
         // configuration page so they can set one
         this._routerExtensions.navigate(['configuration'], {
@@ -359,11 +363,11 @@ export class TabsComponent {
           );
         else
           this._logService.logBreadCrumb(TabsComponent.name, 'Failed to save DailyInfo from PushTracker in Kinvey');
-          // this._logService.logException(
-          //   new Error(
-          //     '[TabsComponent] Failed to save DailyInfo from PushTracker in Kinvey'
-          //   )
-          // );
+        // this._logService.logException(
+        //   new Error(
+        //     '[TabsComponent] Failed to save DailyInfo from PushTracker in Kinvey'
+        //   )
+        // );
       })
       .catch(err => {
         this._logService.logBreadCrumb(TabsComponent.name, 'Failed to save DailyInfo from PushTracker in Kinvey');
@@ -412,11 +416,11 @@ export class TabsComponent {
           );
         else
           this._logService.logBreadCrumb(TabsComponent.name, 'Failed to save Distance from PushTracker in Kinvey');
-          // this._logService.logException(
-          //   new Error(
-          //     '[TabsComponent] Failed to save Distance from PushTracker in Kinvey'
-          //   )
-          // );
+        // this._logService.logException(
+        //   new Error(
+        //     '[TabsComponent] Failed to save Distance from PushTracker in Kinvey'
+        //   )
+        // );
       })
       .catch(err => {
         this._logService.logBreadCrumb(TabsComponent.name, 'Failed to save Distance from PushTracker in Kinvey');
@@ -466,14 +470,14 @@ export class TabsComponent {
           );
         else
           this._logService.logBreadCrumb(TabsComponent.name, 'Failed to save ErrorInfo from PushTracker in Kinvey');
-          // this._logService.logException(
-          //   new Error(
-          //     '[' +
-          //     TabsComponent.name +
-          //     '] ' +
-          //     'Failed to save ErrorInfo from PushTracker in Kinvey'
-          //   )
-          // );
+        // this._logService.logException(
+        //   new Error(
+        //     '[' +
+        //     TabsComponent.name +
+        //     '] ' +
+        //     'Failed to save ErrorInfo from PushTracker in Kinvey'
+        //   )
+        // );
       })
       .catch(err => {
         this._logService.logBreadCrumb(TabsComponent.name, 'Failed to save ErrorInfo from PushTracker in Kinvey');

--- a/apps/mobile/pushtracker/src/app/modules/tabs/tabs.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/tabs/tabs.component.ts
@@ -13,7 +13,7 @@ import throttle from 'lodash/throttle';
 import { hasPermission, requestPermissions } from 'nativescript-permissions';
 import { APP_LANGUAGES, CONFIGURATIONS, STORAGE_KEYS } from '../../enums';
 import { PushTracker, PushTrackerUser } from '../../models';
-import { ActivityService, BluetoothService, LoggingService, SettingsService, SmartDriveErrorsService, SmartDriveUsageService } from '../../services';
+import { ActivityService, BluetoothService, LoggingService, PushTrackerUserService, SettingsService, SmartDriveErrorsService, SmartDriveUsageService } from '../../services';
 import { enableDefaultTheme, YYYY_MM_DD } from '../../utils';
 
 @Component({
@@ -35,6 +35,7 @@ export class TabsComponent {
 
   constructor(
     private _logService: LoggingService,
+    private _userService: PushTrackerUserService,
     private _activityService: ActivityService,
     private _translateService: TranslateService,
     private _settingsService: SettingsService,
@@ -45,6 +46,14 @@ export class TabsComponent {
     private _errorsService: SmartDriveErrorsService
   ) {
     this._logService.logBreadCrumb(TabsComponent.name, 'Constructor');
+
+    // register for user configuration changed event
+    this._userService.on(
+      PushTrackerUserService.configuration_change_event,
+      this.onUserChangedConfiguration,
+      this
+    );
+
     // hide the actionbar on the root tabview
     this._page.actionBarHidden = true;
 
@@ -151,6 +160,16 @@ export class TabsComponent {
           });
       }, 1000);
     }
+  }
+
+  onUserChangedConfiguration(args: any) {
+    this._logService.logBreadCrumb(
+      TabsComponent.name,
+      `Registered user changed configuration: ${args.data.control_configuration}`
+    );
+    const data = args.data;
+    const config = data.control_configuration;
+    this.user.data.control_configuration = config;
   }
 
   onRootBottomNavLoaded(_) {

--- a/apps/mobile/pushtracker/src/app/scss/profile-tab/_profile-tab-dark.scss
+++ b/apps/mobile/pushtracker/src/app/scss/profile-tab/_profile-tab-dark.scss
@@ -12,6 +12,7 @@
   color: $white;
 }
 .date-time-picker-buttons {
+  background-color: $dark-custom-dialog-layout-black;
   color: $permobil-sky;
 }
 

--- a/apps/mobile/pushtracker/src/app/services/activity.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/activity.service.ts
@@ -20,22 +20,26 @@ export class ActivityService {
 
   async reset() {
     this.login();
+    this.refreshDaily();
+    this.refreshWeekly();
+  }
 
-    // now set up the queries to make sure we don't sync more than we need to
-
+  refreshDaily() {
     const _dailyQuery = this.makeQuery();
     // we only ever push data to the daily activity datastore - so
     // we should set a date that is far in the future to keep the
     // pulls from ever actually pulling data
     _dailyQuery.equalTo('date', '2200-01-01');
+    return this.dailyDatastore.sync(_dailyQuery);
+  }
+
+  refreshWeekly() {
     // we actually want to have the weekly datastore storing data
     // locally for use when offline / bad network conditions (and to
     // not have to pull data that we've already seen) so we just set
     // the user id
     const _weeklyQuery = this.makeQuery();
-
-    this.dailyDatastore.sync(_dailyQuery);
-    this.weeklyDatastore.sync(_weeklyQuery);
+    return this.weeklyDatastore.sync(_weeklyQuery);
   }
 
   clear() {

--- a/apps/mobile/pushtracker/src/app/services/activity.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/activity.service.ts
@@ -14,7 +14,10 @@ export class ActivityService {
   public dailyActivity: any;
   public weeklyActivity: any;
 
-  private _query: KinveyQuery;
+  // queries used to control what data is stored on device for each
+  // datastore
+  private _dailyQuery: KinveyQuery;
+  private _weeklyQuery: KinveyQuery;
 
   constructor(private _logService: LoggingService) {
     this.reset();
@@ -22,8 +25,8 @@ export class ActivityService {
 
   async reset() {
     this.login();
-    this.dailyDatastore.sync(this._query);
-    this.weeklyDatastore.sync(this._query);
+    this.dailyDatastore.sync(this._dailyQuery);
+    this.weeklyDatastore.sync(this._weeklyQuery);
   }
 
   clear() {
@@ -68,8 +71,18 @@ export class ActivityService {
   private async login() {
     const activeUser = KinveyUser.getActiveUser();
     if (!!activeUser) {
-      this._query = new KinveyQuery();
-      this._query.equalTo('_acl.creator', activeUser._id);
+      // we only ever push data to the daily activity datastore - so
+      // we should set a date that is far in the future to keep the
+      // pulls from ever actually pulling data
+      this._dailyQuery = new KinveyQuery();
+      this._dailyQuery.equalTo('_acl.creator', activeUser._id);
+      this._dailyQuery.equalTo('date', '2200-01-01');
+      // we actually want to have the weekly datastore storing data
+      // locally for use when offline / bad network conditions (and to
+      // not have to pull data that we've already seen) so we just set
+      // the user id
+      this._weeklyQuery = new KinveyQuery();
+      this._weeklyQuery.equalTo('_acl.creator', activeUser._id);
     } else {
       throw new Error('no active user');
     }

--- a/apps/mobile/pushtracker/src/app/services/activity.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/activity.service.ts
@@ -14,19 +14,28 @@ export class ActivityService {
   public dailyActivity: any;
   public weeklyActivity: any;
 
-  // queries used to control what data is stored on device for each
-  // datastore
-  private _dailyQuery: KinveyQuery;
-  private _weeklyQuery: KinveyQuery;
-
   constructor(private _logService: LoggingService) {
     this.reset();
   }
 
   async reset() {
     this.login();
-    this.dailyDatastore.sync(this._dailyQuery);
-    this.weeklyDatastore.sync(this._weeklyQuery);
+
+    // now set up the queries to make sure we don't sync more than we need to
+
+    const _dailyQuery = this.makeQuery();
+    // we only ever push data to the daily activity datastore - so
+    // we should set a date that is far in the future to keep the
+    // pulls from ever actually pulling data
+    _dailyQuery.equalTo('date', '2200-01-01');
+    // we actually want to have the weekly datastore storing data
+    // locally for use when offline / bad network conditions (and to
+    // not have to pull data that we've already seen) so we just set
+    // the user id
+    const _weeklyQuery = this.makeQuery();
+
+    this.dailyDatastore.sync(_dailyQuery);
+    this.weeklyDatastore.sync(_weeklyQuery);
   }
 
   clear() {
@@ -34,40 +43,55 @@ export class ActivityService {
     this.weeklyDatastore.clear();
   }
 
-  async getWeeklyActivity(date?: string, limit?: number): Promise<any[]> {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const query = new KinveyQuery();
-
-        // configure the query to search for only activity that was
-        // saved by this user, and to get only the most recent activity
-        query.equalTo('_acl.creator', KinveyUser.getActiveUser()._id);
-
-        if (date) {
-          // make sure we only get the weekly activity we are looking for
-          query.equalTo('date', date);
-        }
-        if (limit) {
-          query.limit = limit;
-        }
-        query.descending('_kmd.lmt');
-        this.weeklyDatastore.find(query)
-          .subscribe((data: any[]) => {
-            resolve(data);
-          }, (err) => {
-            console.error('\n', 'error finding weekly activity', err);
-            reject(err);
-          }, () => {
-            // this seems to be called right at the very end - after
-            // we've gotten data, so this resolve will have been
-            // superceded by the resolve(data) above
-            resolve([]);
-          });
-      } catch (err) {
-        console.error('Could not get weekly activity:', err);
-        reject(err);
-      }
+  async _query(db: any, query: KinveyQuery): Promise<any[]> {
+    return new Promise((resolve, reject) => {
+      db.find(query)
+        .subscribe((data: any[]) => {
+          resolve(data);
+        }, (err) => {
+          console.error('\n', 'error finding weekly activity', err);
+          reject(err);
+        }, () => {
+          // this seems to be called right at the very end - after
+          // we've gotten data, so this resolve will have been
+          // superceded by the resolve(data) above
+          resolve([]);
+        });
     });
+  }
+
+  async dailyQuery(query: KinveyQuery): Promise<any[]> {
+    return this._query(this.dailyDatastore, query);
+  }
+
+  async weeklyQuery(query: KinveyQuery): Promise<any[]> {
+    return this._query(this.weeklyDatastore, query);
+  }
+
+  async getWeeklyActivityWithQuery(query: KinveyQuery): Promise<any[]> {
+    // make sure the query only returns data that was created by this
+    // user!
+    query.equalTo('_acl.creator', KinveyUser.getActiveUser()._id);
+    return this.weeklyQuery(query);
+  }
+
+  async getWeeklyActivity(date?: string, limit?: number): Promise<any[]> {
+    const query = new KinveyQuery();
+    // configure the query to search for only activity that was
+    // saved by this user, and to get only the most recent activity
+    query.equalTo('_acl.creator', KinveyUser.getActiveUser()._id);
+    // set the date if they provided it
+    if (date) {
+      // make sure we only get the weekly activity we are looking for
+      query.equalTo('date', date);
+    }
+    // set the limit if they provided it
+    if (limit) {
+      query.limit = limit;
+    }
+    // sort by last modified time descending
+    query.descending('_kmd.lmt');
+    return this.weeklyQuery(query);
   }
 
   async saveDailyActivityFromPushTracker(dailyActivity: any): Promise<boolean> {
@@ -79,23 +103,22 @@ export class ActivityService {
       query.equalTo('_acl.creator', KinveyUser.getActiveUser()._id);
       query.equalTo('date', dailyActivity.date);
 
-      // Run a .find first to get the _id of the daily activity
-      {
-        return this.dailyDatastore.find(query)
-          .then((data: any[]) => {
-            if (data && data.length) {
-              const id = data[0]._id;
-              dailyActivity._id = id;
-            }
-            return this.dailyDatastore.save(dailyActivity)
-              .then((_) => {
-                return true;
-              }).catch((error) => {
-                this._logService.logException(error);
-                return false;
-              });
-          });
-      }
+      // TODO: test this after the update to the Sync datastore type!
+
+      return this.dailyQuery(query)
+        .then((data: any[]) => {
+          if (data && data.length) {
+            const id = data[0]._id;
+            dailyActivity._id = id;
+          }
+          return this.dailyDatastore.save(dailyActivity)
+            .then((_) => {
+              return true;
+            }).catch((error) => {
+              this._logService.logException(error);
+              return false;
+            });
+        });
 
     } catch (err) {
       this._logService.logBreadCrumb(ActivityService.name, 'Failed to save daily activity from pushtracker in Kinvey');
@@ -118,16 +141,7 @@ export class ActivityService {
   private async login() {
     const activeUser = KinveyUser.getActiveUser();
     if (!!activeUser) {
-      this._dailyQuery = this.makeQuery();
-      // we only ever push data to the daily activity datastore - so
-      // we should set a date that is far in the future to keep the
-      // pulls from ever actually pulling data
-      this._dailyQuery.equalTo('date', '2200-01-01');
-      // we actually want to have the weekly datastore storing data
-      // locally for use when offline / bad network conditions (and to
-      // not have to pull data that we've already seen) so we just set
-      // the user id
-      this._weeklyQuery = this.makeQuery();
+      // do nothing - we're good now
     } else {
       throw new Error('no active user');
     }

--- a/apps/mobile/pushtracker/src/app/services/pushtracker.user.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/pushtracker.user.service.ts
@@ -1,51 +1,23 @@
 import { Injectable } from '@angular/core';
-import { PushTrackerUser } from '@permobil/core';
-import { User as KinveyUser } from 'kinvey-nativescript-sdk';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { Observable } from '@nativescript/core';
 
 @Injectable({ providedIn: 'root' })
-export class PushTrackerUserService {
-  private _user: BehaviorSubject<PushTrackerUser>;
-
-  public user: Observable<PushTrackerUser>;
+export class PushTrackerUserService extends Observable {
+  public static configuration_change_event = 'configuration_change_event';
+  public static theme_change_event = 'theme_change_event';
+  public static goal_change_event = 'goal_change_event';
+  public static units_change_event = 'units_change_event';
 
   constructor() {
-    this._user = new BehaviorSubject<PushTrackerUser>(<PushTrackerUser>(
-      (<any>KinveyUser.getActiveUser())
-    ));
-    this.user = this._user.asObservable();
+    super();
   }
 
-  initializeUser(user: PushTrackerUser) {
-    this._user = new BehaviorSubject<PushTrackerUser>(user);
-    this.user = this._user.asObservable();
-    console.log('User initialized', this._user.value);
-  }
-
-  updateUser(user: PushTrackerUser) {
-    this._user.next(user);
-  }
-
-  refreshUser(): Promise<boolean> {
-    return <any>KinveyUser.getActiveUser().me()
-      .then((activeUser) => {
-        this._user.next(<PushTrackerUser>(<any>activeUser));
-        return true;
-      });
-  }
-
-  reset() {
-    this._user = new BehaviorSubject<PushTrackerUser>(<PushTrackerUser>(
-      (<any>KinveyUser.getActiveUser())
-    ));
-    this.user = this._user.asObservable();
-  }
-
-  updateDataProperty(field: string, value: any): void {
-    if (this._user) {
-      const updatedUser = this._user.value;
-      updatedUser.data[field] = value;
-      this._user.next(updatedUser);
-    }
+  emitEvent(eventName: string, data?: any, msg?: string) {
+    this.notify({
+      eventName,
+      object: this,
+      data,
+      message: msg
+    });
   }
 }

--- a/apps/mobile/pushtracker/src/app/services/smartdrive-errors.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/smartdrive-errors.service.ts
@@ -45,7 +45,7 @@ export class SmartDriveErrorsService {
       {
         return this.datastore
           .find(query)
-          .then((data: any[]) => {
+          .subscribe((data: any[]) => {
             if (data && data.length) {
               const id = data[0]._id;
               dailyErrors._id = id;
@@ -57,14 +57,18 @@ export class SmartDriveErrorsService {
               dailyErrors.num_over_temperature_errors += data[0].num_over_temperature_errors || 0;
               dailyErrors.num_ble_disconnect_errors += data[0].num_ble_disconnect_errors || 0;
             }
-            return this.datastore.save(dailyErrors);
-          })
-          .then((_) => {
-            return true;
-          })
-          .catch((error) => {
-            this._logService.logException(error);
+            return this.datastore.save(dailyErrors)
+              .then((_) => {
+                return true;
+              })
+              .catch((error) => {
+                this._logService.logException(error);
+                return false;
+              });
+          }, (err) => {
+            this._logService.logException(err);
             return false;
+          }, () => {
           });
       }
 

--- a/apps/mobile/pushtracker/src/app/services/smartdrive-usage.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/smartdrive-usage.service.ts
@@ -24,22 +24,26 @@ export class SmartDriveUsageService {
 
   async reset() {
     this.login();
+    this.refreshDaily();
+    this.refreshWeekly();
+  }
 
-    // now set up the queries to make sure we don't sync more than we need to
-
+  refreshDaily() {
     const _dailyQuery = this.makeQuery();
     // we only ever push data to the daily activity datastore - so
     // we should set a date that is far in the future to keep the
     // pulls from ever actually pulling data
     _dailyQuery.equalTo('date', '2200-01-01');
+    return this.dailyDatastore.sync(_dailyQuery);
+  }
+
+  refreshWeekly() {
     // we actually want to have the weekly datastore storing data
     // locally for use when offline / bad network conditions (and to
     // not have to pull data that we've already seen) so we just set
     // the user id
     const _weeklyQuery = this.makeQuery();
-
-    this.dailyDatastore.sync(_dailyQuery);
-    this.weeklyDatastore.sync(_weeklyQuery);
+    return this.weeklyDatastore.sync(_weeklyQuery);
   }
 
   clear() {

--- a/apps/mobile/pushtracker/src/app/services/smartdrive-usage.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/smartdrive-usage.service.ts
@@ -41,25 +41,31 @@ export class SmartDriveUsageService {
   async getWeeklyActivity(date?: string, limit?: number): Promise<any> {
     // initialize the query from the query that we have (which
     // contains the user id)
-    const query = this.makeQuery();
-    if (date) {
-      // make sure we only get the weekly activity we are looking for
-      query.equalTo('date', date);
+    try {
+      const query = new KinveyQuery();
+
+      // configure the query to search for only activity that was
+      // saved by this user, and to get only the most recent activity
+      query.equalTo('_acl.creator', KinveyUser.getActiveUser()._id);
+
+      if (date) {
+        // make sure we only get the weekly activity we are looking for
+        query.equalTo('date', date);
+      }
+      if (limit) {
+        query.limit = limit;
+      }
+      query.descending('_kmd.lmt');
+      return this.weeklyDatastore.find(query)
+        .subscribe((data: any[]) => {
+          return data;
+        }, (err) => {
+          console.error('\n', 'error finding weekly usage', err);
+        }, () => {
+        });
+    } catch (err) {
+      console.error('Could not get weekly usage:', err);
     }
-    if (limit) {
-      query.limit = limit;
-    }
-    query.descending('_kmd.lmt');
-    console.log('getting usage data for date:', date);
-    console.log('loading weekly usage for user', query.toString());
-    return this.weeklyDatastore.find(query)
-      .then((data: any[]) => {
-        console.log('GOT DATA:', data);
-        if (data && data.length) {
-          console.log('ACTUALLY HAVE DATA', data[0]);
-        }
-        return data;
-      });
   }
 
   async saveDailyUsageFromPushTracker(dailyUsage: any): Promise<boolean> {


### PR DESCRIPTION
Replace manual http queries with calls to kinvey {N} sdk. Update handling of user data to use kinvey's user information instead of manually calling http requests to fetch the user. Removes the use of the `PushTrackerUserService::user::subscribe(...)` and instead uses `Kinvey.User.getActiveUser()`, `user.me()` to refresh, and `PushTrackerUserService` events to propagate changes that aren't automatically tracked.

This should close these issues:
- [x] #462 
- [x] #510 - we're moving away from `DataStoreType.Auto` to `DataStoreType.Sync` which should improve the process of saving multiple entries in a row (which will now automatically sync to the backend at a later time)
- [x] #519 
- [x] #520 
- [x] #522 - similarly to #510, we should not see this anymore since we're using `Sync` data store type now