### PR TITLE
Bugfix/548

### DIFF
--- a/apps/mobile/pushtracker/src/app/models/pushtracker.model.ts
+++ b/apps/mobile/pushtracker/src/app/models/pushtracker.model.ts
@@ -820,10 +820,12 @@ export class PushTracker extends Observable {
   }
 
   handleConnect() {
+    if (!this.connected) {
+      this.sendEvent(PushTracker.connect_event);
+      // send set time command on first connection
+      this.sendTime();
+    }
     this.connected = true;
-    this.sendEvent(PushTracker.connect_event);
-    // send set time command on first connection
-    this.sendTime();
   }
 
   handleDisconnect() {

--- a/apps/mobile/pushtracker/src/app/services/bluetooth.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/bluetooth.service.ts
@@ -365,9 +365,9 @@ export class BluetoothService extends Observable {
     return this._bluetooth.disconnect(args);
   }
 
-  discoverServices(_: any) {}
+  discoverServices(_: any) { }
 
-  discoverCharacteristics(_: any) {}
+  discoverCharacteristics(_: any) { }
 
   startNotifying(opts: any) {
     return this._bluetooth.startNotifying(opts);
@@ -468,7 +468,7 @@ export class BluetoothService extends Observable {
     }
   }
 
-  private onDeviceNameChange(_: any): void {}
+  private onDeviceNameChange(_: any): void { }
 
   private onDeviceUuidChange(_: any): void {
     // TODO: This function doesn't work (android BT impl returns null)
@@ -511,11 +511,13 @@ export class BluetoothService extends Observable {
       case ConnectionState.connected:
         if (this.isPushTracker(device)) {
           const pt = this.getOrMakePushTracker(device);
+          if (!pt.connected) {
+            this.sendEvent(BluetoothService.pushtracker_connected, {
+              pushtracker: pt
+            });
+          }
           pt.handleConnect();
           this.updatePushTrackerState();
-          this.sendEvent(BluetoothService.pushtracker_connected, {
-            pushtracker: pt
-          });
         } else if (this.isSmartDrive(device)) {
           const sd = this.getOrMakeSmartDrive(device);
           sd.handleConnect();
@@ -606,7 +608,7 @@ export class BluetoothService extends Observable {
     p.destroy();
   }
 
-  private onCharacteristicReadRequest(_: any): void {}
+  private onCharacteristicReadRequest(_: any): void { }
 
   // service controls
   private deleteServices() {

--- a/apps/mobile/pushtracker/src/app/services/bluetooth.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/bluetooth.service.ts
@@ -515,9 +515,9 @@ export class BluetoothService extends Observable {
             this.sendEvent(BluetoothService.pushtracker_connected, {
               pushtracker: pt
             });
+            pt.handleConnect();
+            this.updatePushTrackerState();
           }
-          pt.handleConnect();
-          this.updatePushTrackerState();
         } else if (this.isSmartDrive(device)) {
           const sd = this.getOrMakeSmartDrive(device);
           sd.handleConnect();


### PR DESCRIPTION
Update connection management code in bluetooth service to not fire duplicate events - mainly on iOS where the `server_connection_state_changed` event fires from the `CBPeripheralManagerDelegateImpl::peripheralManagerCentralDidSubscribeToCharacteristic` - which calls once for each characteristic (there are 4) that the pushtracker subscribes to