### PR TITLE
Update settings service to use Sync datastoretype instead of auto

### DIFF
--- a/apps/mobile/pushtracker/src/app/modules/tabs/tabs.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/tabs/tabs.component.ts
@@ -639,7 +639,9 @@ export class TabsComponent {
         case this._translateService.instant('actions.overwrite-local-settings'):
           this._settingsService.settings.copy(s);
           this._settingsService.saveToFileSystem();
-          this._settingsService.save().catch(Log.E);
+          try {
+            await this._settingsService.save();
+          } catch (err) { Log.E(err); }
           break;
         case this._translateService.instant(
           'actions.overwrite-remote-settings'
@@ -677,7 +679,9 @@ export class TabsComponent {
         case this._translateService.instant('actions.overwrite-local-settings'):
           this._settingsService.switchControlSettings.copy(s);
           this._settingsService.saveToFileSystem();
-          this._settingsService.save().catch(Log.E);
+          try {
+            await this._settingsService.save();
+          } catch (err) { Log.E(err); }
           break;
         case this._translateService.instant(
           'actions.overwrite-remote-settings'

--- a/apps/mobile/pushtracker/src/app/services/settings.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/settings.service.ts
@@ -35,10 +35,11 @@ export class SettingsService {
   }
 
   async refresh() {
-    // we actually want to have the datastore storing data locally for
-    // use when offline / bad network conditions (and to not have to
-    // pull data that we've already seen) so we just set the user id
     const query = this.makeQuery();
+    // we're only ever interested in the latest data from the server
+    query.descending('_kmd.lmt');
+    query.limit = 1;
+    // query.equalTo('date', '2200-01-01');
     await this.datastore.sync(query);
   }
 

--- a/apps/mobile/pushtracker/src/app/services/smartdrive-errors.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/smartdrive-errors.service.ts
@@ -12,10 +12,6 @@ import { connectionType, getConnectionType } from '@nativescript/core/connectivi
 @Injectable()
 export class SmartDriveErrorsService {
   private datastore = KinveyDataStore.collection('DailyPushTrackerErrors', DataStoreType.Sync);
-  public dailyActivity: any;
-  public weeklyActivity: any;
-  private _usageUpdated = new BehaviorSubject<boolean>(false);
-  usageUpdated = this._usageUpdated.asObservable();
 
   constructor(private _logService: LoggingService) {
     this.reset();

--- a/apps/mobile/pushtracker/src/app/services/smartdrive-usage.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/smartdrive-usage.service.ts
@@ -13,10 +13,6 @@ import { connectionType, getConnectionType } from '@nativescript/core/connectivi
 export class SmartDriveUsageService {
   private dailyDatastore = KinveyDataStore.collection('DailySmartDriveUsage', DataStoreType.Sync);
   private weeklyDatastore = KinveyDataStore.collection('WeeklySmartDriveUsage', DataStoreType.Sync);
-  public dailyActivity: any;
-  public weeklyActivity: any;
-  private _usageUpdated = new BehaviorSubject<boolean>(false);
-  usageUpdated = this._usageUpdated.asObservable();
 
   constructor(private _logService: LoggingService) {
     this.reset();


### PR DESCRIPTION
Refactored settings service to be more similar to the smartdrive-usage.service and the smartdrive-errors.service. Do not try to sync and push every time we save data to the datastore - let the datastore handle that itself.