### PR TITLE
Feature/561

### DIFF
--- a/apps/wear/smartdrive/app/App_Resources/Android/src/main/java/com/permobil/smartdrive/wearos/watchface/digital/DigitalWatchFaceService.java
+++ b/apps/wear/smartdrive/app/App_Resources/Android/src/main/java/com/permobil/smartdrive/wearos/watchface/digital/DigitalWatchFaceService.java
@@ -331,16 +331,23 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
             super.onAmbientModeChanged(inAmbientMode);
             Log.d(TAG, "onAmbientModeChanged: " + inAmbientMode);
 
+            Resources res = getResources();
+            Resources.Theme theme = getTheme();
+
             if (inAmbientMode) {
+                int ambientColor = res.getColor(R.color.ambient_mode_text, theme);
+                int transparentColor = res.getColor(R.color.transparent, theme);
+
                 if (smartDriveBtn != null) {
                     smartDriveBtn.setVisibility(View.GONE);
                 }
                 if (watchBatteryCircle != null) {
-                    watchBatteryCircle.setBarColor(getResources().getColor(R.color.ambient_mode_text, getTheme()));
+                    watchBatteryCircle.setBarColor(ambientColor);
+                    watchBatteryCircle.setRimColor(transparentColor);
                 }
                 if (smartDriveBatteryCircle != null) {
-                    smartDriveBatteryCircle.setBarColor(getResources().getColor(R.color.ambient_mode_text, getTheme()));
-                    Log.d(TAG, "hard coding the smartdrive value right now, need to get it from complication data available");
+                    smartDriveBatteryCircle.setBarColor(ambientColor);
+                    smartDriveBatteryCircle.setRimColor(transparentColor);
                 }
 
                 hourTextView.setTextSize(46);
@@ -350,14 +357,20 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
                 // always draw the colon with the time in ambient mode
                 colonTextView.setVisibility(View.VISIBLE);
             } else {
+                int oceanColor = res.getColor(R.color.permobil_ocean, theme);
+                int primaryColor = res.getColor(R.color.permobil_ocean, theme);
+                int grayColor = res.getColor(R.color.gray, theme);
+
                 if (smartDriveBtn != null) {
                     smartDriveBtn.setVisibility(View.VISIBLE);
                 }
                 if (watchBatteryCircle != null) {
-                    watchBatteryCircle.setBarColor(getResources().getColor(R.color.permobil_ocean, getTheme()));
+                    watchBatteryCircle.setBarColor(oceanColor);
+                    watchBatteryCircle.setRimColor(grayColor);
                 }
                 if (smartDriveBatteryCircle != null) {
-                    smartDriveBatteryCircle.setBarColor(getResources().getColor(R.color.permobil_primary, getTheme()));
+                    smartDriveBatteryCircle.setBarColor(primaryColor);
+                    smartDriveBatteryCircle.setRimColor(grayColor);
                 }
 
                 hourTextView.setTextSize(24);

--- a/apps/wear/smartdrive/app/App_Resources/Android/src/main/java/com/permobil/smartdrive/wearos/watchface/digital/DigitalWatchFaceService.java
+++ b/apps/wear/smartdrive/app/App_Resources/Android/src/main/java/com/permobil/smartdrive/wearos/watchface/digital/DigitalWatchFaceService.java
@@ -32,6 +32,7 @@ import android.view.WindowInsets;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
+import android.widget.TableRow;
 import android.widget.TextView;
 
 import com.permobil.smartdrive.wearos.R;
@@ -151,6 +152,8 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
         TextView minuteTextView;
         @BindView(R.id.amPmTextView)
         TextView amPmTextView;
+        @BindView(R.id.spaceTableRow)
+        TableRow spaceTableRow;
 
         /**
          * Alpha value for drawing time when in mute mode.
@@ -338,6 +341,10 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
                 int ambientColor = res.getColor(R.color.ambient_mode_text, theme);
                 int transparentColor = res.getColor(R.color.transparent, theme);
 
+                // hide the space TableRow and the SD Button from layout so the time shifts up in ambient
+                if (spaceTableRow != null) {
+                    spaceTableRow.setVisibility(View.GONE);
+                }
                 if (smartDriveBtn != null) {
                     smartDriveBtn.setVisibility(View.GONE);
                 }
@@ -350,9 +357,9 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
                     smartDriveBatteryCircle.setRimColor(transparentColor);
                 }
 
-                hourTextView.setTextSize(46);
-                colonTextView.setTextSize(46);
-                minuteTextView.setTextSize(46);
+                hourTextView.setTextSize(48);
+                colonTextView.setTextSize(48);
+                minuteTextView.setTextSize(48);
 
                 // always draw the colon with the time in ambient mode
                 colonTextView.setVisibility(View.VISIBLE);
@@ -361,6 +368,10 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
                 int primaryColor = res.getColor(R.color.permobil_ocean, theme);
                 int grayColor = res.getColor(R.color.gray, theme);
 
+                // Make sure the space TableRow and the SD Button are visible in active mode
+                if (spaceTableRow != null) {
+                    spaceTableRow.setVisibility(View.VISIBLE);
+                }
                 if (smartDriveBtn != null) {
                     smartDriveBtn.setVisibility(View.VISIBLE);
                 }
@@ -494,22 +505,11 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
         public void onApplyWindowInsets(WindowInsets insets) {
             super.onApplyWindowInsets(insets);
             Log.d(TAG, "onApplyWindowInsets: " + (insets.isRound() ? "round" : "square"));
-
-            // Load resources that have alternate values for round watches.
-//            Resources resources = DigitalWatchFaceService.this.getResources();
-//            boolean isRound = insets.isRound();
-//            mXOffset = resources.getDimension(isRound ? R.dimen.digital_x_offset_round : R.dimen.digital_x_offset);
-//            float textSize = resources.getDimension(isRound ? R.dimen.digital_text_size_round : R.dimen.digital_text_size);
-//            float amPmSize = resources.getDimension(isRound ? R.dimen.digital_am_pm_size_round : R.dimen.digital_am_pm_size);
         }
 
         private void initSentrySetup() {
             // Setup Sentry logging, uses `sentry.properties`
             Sentry.init();
-            /*
-            Record a breadcrumb in the current context which will be sent
-            with the next event(s). By default the last 100 breadcrumbs are kept.
-            */
             Sentry.getContext().recordBreadcrumb(
                     new BreadcrumbBuilder().setMessage("SmartDrive MX2 Digital WatchFace started.").build()
             );

--- a/apps/wear/smartdrive/app/App_Resources/Android/src/main/res/layout/activity_config.xml
+++ b/apps/wear/smartdrive/app/App_Resources/Android/src/main/res/layout/activity_config.xml
@@ -143,28 +143,31 @@
                     <TextView
                         android:id="@+id/hourTextView"
                         android:layout_width="wrap_content"
-                        android:layout_height="30dp"
+                        android:layout_height="wrap_content"
                         android:fontFamily="sans-serif-light"
                         android:text="@string/_12"
                         android:textAlignment="viewEnd"
+                        android:textColor="@color/ambient_mode_text"
                         android:textSize="24sp" />
 
                     <TextView
                         android:id="@+id/colonTextView"
                         android:layout_width="10dp"
-                        android:layout_height="30dp"
+                        android:layout_height="wrap_content"
                         android:fontFamily="sans-serif-light"
                         android:text="@string/colon"
                         android:textAlignment="center"
+                        android:textColor="@color/ambient_mode_text"
                         android:textSize="24sp" />
 
                     <TextView
                         android:id="@+id/minuteTextView"
                         android:layout_width="wrap_content"
-                        android:layout_height="30dp"
+                        android:layout_height="wrap_content"
                         android:fontFamily="sans-serif-light"
                         android:text="@string/_00"
                         android:textAlignment="textStart"
+                        android:textColor="@color/ambient_mode_text"
                         android:textSize="24sp" />
                 </LinearLayout>
 
@@ -182,7 +185,8 @@
                     android:fontFamily="sans-serif-light"
                     android:gravity="center"
                     android:text="@string/pm"
-                    android:textAlignment="center" />
+                    android:textAlignment="center"
+                    android:textColor="@color/ambient_mode_text" />
             </TableRow>
 
         </TableLayout>
@@ -201,54 +205,4 @@
         android:visibility="visible"
         tools:src="@drawable/ic_battery_full" />
 
-</RelativeLayout><!--    -->
-    <!--    <?xml version="1.0" encoding="utf-8"?>-->
-    <!--<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"-->
-    <!--    android:layout_width="match_parent"-->
-    <!--    android:layout_height="match_parent"-->
-    <!--    android:background="@color/black"-->
-    <!--    android:orientation="vertical">-->
-
-    <!--    <RelativeLayout-->
-    <!--        android:layout_width="match_parent"-->
-    <!--        android:layout_height="wrap_content">-->
-
-    <!--        <ImageView-->
-    <!--            android:id="@+id/top_complication_background"-->
-    <!--            style="?android:borderlessButtonStyle"-->
-    <!--            android:layout_width="match_parent"-->
-    <!--            android:layout_height="wrap_content"-->
-    <!--            android:layout_marginTop="10dp"-->
-    <!--            android:background="@android:color/transparent"-->
-    <!--            android:contentDescription="@string/topcomplicationbackground"-->
-    <!--            android:src="@drawable/add_complication" />-->
-
-    <!--        <ImageButton-->
-    <!--            android:id="@+id/top_complication"-->
-    <!--            style="?android:borderlessButtonStyle"-->
-    <!--            android:layout_width="match_parent"-->
-    <!--            android:layout_height="wrap_content"-->
-    <!--            android:layout_marginTop="10dp"-->
-    <!--            android:background="@android:color/transparent"-->
-    <!--            android:contentDescription="@string/topcomplication" />-->
-
-    <!--    </RelativeLayout>-->
-
-
-    <!--    <ImageView-->
-    <!--        android:id="@+id/imageView"-->
-    <!--        android:layout_width="match_parent"-->
-    <!--        android:layout_height="wrap_content"-->
-    <!--        android:contentDescription="@string/smartdriveimagebutton"-->
-    <!--        android:src="@drawable/smartdrive_button" />-->
-
-    <!--    <TextView-->
-    <!--        android:id="@+id/timeTextView"-->
-    <!--        android:layout_width="match_parent"-->
-    <!--        android:layout_height="wrap_content"-->
-    <!--        android:text="@string/noonTime"-->
-    <!--        android:textAlignment="center"-->
-    <!--        android:textSize="24sp"-->
-    <!--        android:textStyle="bold" />-->
-
-    <!--</LinearLayout>-->
+</RelativeLayout>

--- a/apps/wear/smartdrive/app/App_Resources/Android/src/main/res/values/ids.xml
+++ b/apps/wear/smartdrive/app/App_Resources/Android/src/main/res/values/ids.xml
@@ -7,6 +7,7 @@
   <item name="colonTextView" type="id"/>
   <item name="minuteTextView" type="id"/>
   <item name="amPmTextView" type="id"/>
+  <item name="spaceTableRow" type="id"/>
 
   <item name="top_complication_background" type="id"/>
   <item name="top_complication" type="id"/>


### PR DESCRIPTION
Closes #561 

- Hides the `TableRow` above SD button to allow time strings to shift further up to center of layout
- Fixes time color in the config Activity so it renders
- Set transparent rim-color on the battery/sd circles in ambient mode