### PR TITLE
Feature/580

### DIFF
--- a/apps/mobile/pushtracker/src/app/assets/i18n/en.json
+++ b/apps/mobile/pushtracker/src/app/assets/i18n/en.json
@@ -1,4 +1,6 @@
 {
+  "sd-battery": "SmartDrive Battery",
+  "pt-battery": "PushTracker Battery",
 	"actions": {
 		"keep-both-settings": "Do not change either settings.",
 		"overwrite-local-settings": "Overwrite app's settings.",

--- a/apps/mobile/pushtracker/src/app/models/pushtracker.model.ts
+++ b/apps/mobile/pushtracker/src/app/models/pushtracker.model.ts
@@ -70,6 +70,7 @@ export class PushTracker extends DeviceBase {
   events: any /*IPushTrackerEvents*/;
 
   //  members - in addition to Device Base
+  sdBattery = 0; // stored battery information about smartdrive
   version = 0xff; // firmware version number for the PT firmware
   paired = false; // Is this PushTracker paired?
   settings = new Device.Settings();
@@ -108,6 +109,7 @@ export class PushTracker extends DeviceBase {
       mcu_version: this.mcu_version,
       ble_version: this.ble_version,
       battery: this.battery,
+      sdBattery: this.sdBattery,
       address: this.address,
       paired: this.paired,
       connected: this.connected
@@ -119,6 +121,7 @@ export class PushTracker extends DeviceBase {
     this.mcu_version = (obj && obj.mcu_version) || 0xff;
     this.ble_version = (obj && obj.ble_version) || 0xff;
     this.battery = (obj && obj.battery) || 0;
+    this.sdBattery = (obj && obj.sdBattery) || 0;
     this.address = (obj && obj.address) || '';
     this.paired = (obj && obj.paired) || false;
     this.connected = (obj && obj.connected) || false;
@@ -909,6 +912,10 @@ export class PushTracker extends DeviceBase {
            uint8_t     sdBattery;       /** Percent, [0, 100].
            }            dailyInfo;
     */
+    // set the battery for
+    // https://github.com/Max-Mobility/permobil-client/issues/580
+    this.battery = di.ptBattery;
+    this.sdBattery = di.sdBattery;
     // Properly check against invalid dates (null or in the future)
     // https://github.com/Max-Mobility/permobil-client/issues/546
     const year = di.year;

--- a/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.html
+++ b/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.html
@@ -94,13 +94,13 @@
         <Label textWrap="true" row="1" col="4" class="detail-description" [text]="(user?.data.distance_unit_preference === DISTANCE_UNITS.KILOMETERS ? 'general.odometer-km' : 'general.odometer') | translate"></Label>
       </GridLayout>
 
-      <GridLayout *ngIf="hasBatteryInfo" rows="auto, auto" columns="*, *, *, *, *" class="detail-data">
+      <GridLayout *ngIf="showBatteryInfo" rows="auto, auto" columns="*, *" class="detail-data">
         // pushtracker battery data
-        <Label row="0" col="1" class="detail-value" [text]="ptBattery"></Label>
-        <Label textWrap="true" row="1" col="1" class="detail-description" [text]="'pt-battery' | translate"></Label>
+        <Label row="0" col="0" class="detail-value" [text]="ptBattery"></Label>
+        <Label textWrap="true" row="1" col="0" class="detail-description" [text]="'pt-battery' | translate"></Label>
         // smartdrive battery data
-        <Label row="0" col="3" class="detail-value" [text]="sdBattery"></Label>
-        <Label textWrap="true" row="1" col="3" class="detail-description" [text]="'sd-battery' | translate"></Label>
+        <Label row="0" col="1" class="detail-value" [text]="sdBattery"></Label>
+        <Label textWrap="true" row="1" col="1" class="detail-description" [text]="'sd-battery' | translate"></Label>
       </GridLayout>
 
       // Coast Time Chart

--- a/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.html
+++ b/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.html
@@ -94,12 +94,12 @@
         <Label textWrap="true" row="1" col="4" class="detail-description" [text]="(user?.data.distance_unit_preference === DISTANCE_UNITS.KILOMETERS ? 'general.odometer-km' : 'general.odometer') | translate"></Label>
       </GridLayout>
 
-      <GridLayout rows="auto, auto" columns="*, *, *, *, *" class="detail-data" [visibility]="hasBatteryInfo ? 'visible':'collapsed'">
+      <GridLayout *ngIf="hasBatteryInfo" rows="auto, auto" columns="*, *, *, *, *" class="detail-data">
         // pushtracker battery data
-        <Label row="0" col="1" class="detail-value" [text]="ptBattery + '%'"></Label>
+        <Label row="0" col="1" class="detail-value" [text]="ptBattery"></Label>
         <Label textWrap="true" row="1" col="1" class="detail-description" [text]="'pt-battery' | translate"></Label>
         // smartdrive battery data
-        <Label row="0" col="3" class="detail-value" [text]="sdBattery + '%'"></Label>
+        <Label row="0" col="3" class="detail-value" [text]="sdBattery"></Label>
         <Label textWrap="true" row="1" col="3" class="detail-description" [text]="'sd-battery' | translate"></Label>
       </GridLayout>
 

--- a/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.html
+++ b/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.html
@@ -94,6 +94,15 @@
         <Label textWrap="true" row="1" col="4" class="detail-description" [text]="(user?.data.distance_unit_preference === DISTANCE_UNITS.KILOMETERS ? 'general.odometer-km' : 'general.odometer') | translate"></Label>
       </GridLayout>
 
+      <GridLayout rows="auto, auto" columns="*, *, *, *, *" class="detail-data" [visibility]="hasBatteryInfo ? 'visible':'collapsed'">
+        // pushtracker battery data
+        <Label row="0" col="1" class="detail-value" [text]="ptBattery + '%'"></Label>
+        <Label textWrap="true" row="1" col="1" class="detail-description" [text]="'pt-battery' | translate"></Label>
+        // smartdrive battery data
+        <Label row="0" col="3" class="detail-value" [text]="sdBattery + '%'"></Label>
+        <Label textWrap="true" row="1" col="3" class="detail-description" [text]="'sd-battery' | translate"></Label>
+      </GridLayout>
+
       // Coast Time Chart
       <GridLayout rows="auto, *" columns="*" horizontalAlignment="center" class="chart-layout">
         <FlexboxLayout width="80%" horizontalAlignment="center" flexWrap="wrap" alignContent="flex-start">

--- a/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/home-tab/home-tab.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewContainerRef } from '@angular/core';
+import { Component, NgZone, ViewContainerRef } from '@angular/core';
 import { PushTrackerKinveyKeys } from '@maxmobility/private-keys';
 import { ModalDialogService } from '@nativescript/angular';
 import { Color, ObservableArray, ChangedData } from '@nativescript/core';
@@ -48,8 +48,8 @@ export class HomeTabComponent {
   coastDistanceYAxisStep: number = 0.25;
 
   hasBatteryInfo: boolean = false;
-  ptBattery: number = 0;
-  sdBattery: number = 0;
+  ptBattery: string = '--';
+  sdBattery: string = '--';
 
   todayMessage: string = '';
   todayCoastDistance: string = '0.0';
@@ -75,6 +75,7 @@ export class HomeTabComponent {
   private _weeklyUsageFromKinvey: any;
 
   constructor(
+    private _zone: NgZone,
     private _translateService: TranslateService,
     private _logService: LoggingService,
     private _modalService: ModalDialogService,
@@ -168,9 +169,12 @@ export class HomeTabComponent {
 
   onPushTrackerDailyInfo(args: any) {
     const pt = args.object as PushTracker;
-    this.hasBatteryInfo = true;
-    this.ptBattery = pt.battery;
-    this.sdBattery = pt.sdBattery;
+    console.log('got daily info event', pt.battery);
+    this._zone.run(() => {
+      this.hasBatteryInfo = true;
+      this.ptBattery = pt.battery + '%';
+      this.sdBattery = pt.sdBattery ? (pt.sdBattery + '%') : '--';
+    });
   }
 
   // Update what is displayed in the center of the home-tab circle #263

--- a/apps/mobile/pushtracker/src/app/modules/shared/components/pushtracker-status-button/pushtracker-status-button.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/shared/components/pushtracker-status-button/pushtracker-status-button.component.ts
@@ -58,7 +58,11 @@ export class PushTrackerStatusButtonComponent {
   }
 
   onUnloaded() {
-    this._bluetoothService.off(BluetoothService.pushtracker_status_changed);
+    this._bluetoothService.off(
+      BluetoothService.pushtracker_status_changed,
+      this._updateWatchState,
+      this
+    );
   }
 
   private _updateWatchState() {

--- a/apps/mobile/pushtracker/src/app/modules/shared/components/pushtracker-status-button/pushtracker-status-button.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/shared/components/pushtracker-status-button/pushtracker-status-button.component.ts
@@ -92,7 +92,6 @@ export class PushTrackerStatusButtonComponent {
 
     // get the pts needed
     const pts = BluetoothService.PushTrackers.filter(pt => pt.connected);
-    let pt = null;
     if (allowOnlyOneConnected) {
       pts.splice(1, pts.length - 1);
     }

--- a/apps/mobile/pushtracker/src/app/modules/shared/components/pushtracker-status-button/pushtracker-status-button.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/shared/components/pushtracker-status-button/pushtracker-status-button.component.ts
@@ -76,16 +76,58 @@ export class PushTrackerStatusButtonComponent {
   }
 
   onTap() {
+    const title = this._translateService.instant(
+      'profile-settings.watch-status-alert-title'
+    );
+    const msg = this.getMessage();
     alert({
-      title: this._translateService.instant(
-        'profile-settings.watch-status-alert-title'
-      ),
-      message: this._translateService.instant(
-        'profile-settings.watch-status-alert-message.' +
-          this._getTranslationKeyForPushTrackerStatus()
-      ),
+      title: title,
+      message: msg,
       okButtonText: this._translateService.instant('dialogs.ok')
     });
+  }
+
+  private getBatteryMessage(allowOnlyOneConnected: boolean = true) {
+    let msg = '';
+
+    // get the pts needed
+    const pts = BluetoothService.PushTrackers.filter(pt => pt.connected);
+    let pt = null;
+    if (allowOnlyOneConnected) {
+      pts.splice(1, pts.length - 1);
+    }
+    pts.forEach(pt => {
+      const ptBattery = pt && pt.battery;
+      const sdBattery = pt && pt.sdBattery;
+      if (ptBattery) {
+        switch (this.state) {
+          case PushTrackerState.busy:
+          case PushTrackerState.connected:
+          case PushTrackerState.ready:
+            msg += '\n';
+            msg += this._translateService.instant(
+              'pt-battery'
+            ) + `: ${ptBattery.toFixed(0)}%`;
+            msg += '\n';
+            msg += this._translateService.instant(
+              'sd-battery'
+            ) + `: ${sdBattery.toFixed(0)}%`;
+            break;
+          default:
+            break;
+        }
+      }
+    });
+    return msg;
+  }
+
+  private getMessage() {
+    let msg = this._translateService.instant(
+      'profile-settings.watch-status-alert-message.' +
+      this._getTranslationKeyForPushTrackerStatus()
+    );
+    msg += this.getBatteryMessage(false);
+    return msg;
   }
 
   private _getTranslationKeyForPushTrackerStatus() {

--- a/apps/mobile/pushtracker/src/app/services/bluetooth.service.ts
+++ b/apps/mobile/pushtracker/src/app/services/bluetooth.service.ts
@@ -26,7 +26,9 @@ export class BluetoothService extends Observable {
   static PushTrackers = new ObservableArray<PushTracker>();
   static SmartDrives = new ObservableArray<SmartDrive>();
 
+  public static advertise_success = 'advertise_success';
   public static advertise_error = 'advertise_error';
+  public static pushtracker_added = 'pushtracker_added';
   public static pushtracker_connected = 'pushtracker_connected';
   public static pushtracker_disconnected = 'pushtracker_disconnected';
   public static smartdrive_connected = 'smartdrive_connected';
@@ -271,6 +273,8 @@ export class BluetoothService extends Observable {
     this._bluetooth.addService(this.AppService);
 
     this.advertising = true;
+
+    this.sendEvent(BluetoothService.advertise_success);
 
     return Promise.resolve();
   }
@@ -766,6 +770,7 @@ export class BluetoothService extends Observable {
     if (pt === null || pt === undefined) {
       pt = new PushTracker(this, { address: device.address });
       BluetoothService.PushTrackers.push(pt);
+      this.sendEvent(BluetoothService.pushtracker_added, { pt });
     }
     if (device.device) {
       pt.device = device.device;


### PR DESCRIPTION
* Improves event handling / management throughout app
* Adds PT / SD battery info to alert in `pushtracker-status-component` (#580)
* Adds PT / SD battery display to home tab (#580)
* Ensures time is properly sent to PT (#581 )
* Fixes overly restrictive date checking in error and daily info (#583 )