### PR TITLE
Bug: 639 - Watch Time in ambient mode update

### DIFF
--- a/apps/wear/smartdrive/app/App_Resources/Android/src/main/java/com/permobil/smartdrive/wearos/util/DateUtils.java
+++ b/apps/wear/smartdrive/app/App_Resources/Android/src/main/java/com/permobil/smartdrive/wearos/util/DateUtils.java
@@ -5,8 +5,8 @@ import java.util.Locale;
 
 public class DateUtils {
 
-    public static String formatTwoDigitNumber(int hour) {
-        return String.format(Locale.getDefault(), "%02d", hour);
+    public static String formatTwoDigitNumber(int value) {
+        return String.format(Locale.getDefault(), "%02d", value);
     }
 
     public static String getAmPmString(int amPm) {

--- a/apps/wear/smartdrive/app/App_Resources/Android/src/main/java/com/permobil/smartdrive/wearos/watchface/digital/DigitalWatchFaceService.java
+++ b/apps/wear/smartdrive/app/App_Resources/Android/src/main/java/com/permobil/smartdrive/wearos/watchface/digital/DigitalWatchFaceService.java
@@ -60,7 +60,7 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
     private int ambientColor;
     private SharedPreferences sharedPreferences;
 
-
+    
     /**
      * Update rate in milliseconds for normal (not ambient and not mute) mode. We update twice
      * a second to blink the colons.
@@ -641,6 +641,18 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
             }
             colonTextView.setVisibility(mShouldDrawColons ? View.VISIBLE : View.INVISIBLE);
 
+            // Get the minutes.
+            String minuteString;
+            int minute = mCalendar.get(Calendar.MINUTE);
+            // HACK - for some reason when we are setting the value of the string in Ambient Mode it's using the previous value.
+            // so here we are just incrementing the string value +1 to force the minutes in ambient mode to be in sync with what the system clock is
+            // For now this seems to be working fine... will need to analyze with other devices and more testing feedback.
+            // https://github.com/Max-Mobility/permobil-client/issues/639
+            if (isInAmbientMode()) {
+                minute = ((minute) + 1) % 60;
+            }
+            minuteString = DateUtils.formatTwoDigitNumber(minute);
+            minuteTextView.setText(minuteString);
 
             // Get the hours.
             String hourString;
@@ -648,6 +660,14 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
                 hourString = DateUtils.formatTwoDigitNumber(mCalendar.get(Calendar.HOUR_OF_DAY));
             } else {
                 int hour = mCalendar.get(Calendar.HOUR);
+
+                // handle updating the hour in ambient mode - if the minutes have rolled around to 00
+                // https://github.com/Max-Mobility/permobil-client/issues/639
+                if (isInAmbientMode() && minute == 0) {
+                    // we need to bump the hour +1 around the clock our minutes are updating in ambient here
+                    hour = (hour + 1);
+                }
+
                 if (hour == 0) {
                     hour = 12;
                 }
@@ -655,16 +675,6 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
             }
             hourTextView.setText(hourString);
 
-            // Get the minutes.
-            String minuteString = DateUtils.formatTwoDigitNumber(mCalendar.get(Calendar.MINUTE));
-            // HACK - for some reason when we are setting the value of the string in Ambient Mode it's using the previous value.
-            // so here we are just incrementing the string value +1 to force the minutes in ambient mode to be in sync with what the system clock is
-            // For now this seems to be working fine... will need to analyze with other devices and more testing feedback.
-            if (isInAmbientMode()) {
-                int i = (Integer.parseInt(minuteString) + 1);
-                minuteString = DateUtils.formatTwoDigitNumber(i);
-            }
-            minuteTextView.setText(minuteString);
 
             // Set the am/pm.
             if (!is24Hour) {


### PR DESCRIPTION
Not happy having to keep the hack, definitely think there is an underlying WearOS bug we don't know about or something we should be doing that isn't documented. 

I've debugged the textview at runtime and the values and everything logs correctly, even `getText()` on the TV after set to the Calendar.MINUTE outputs the correct value for the calendar, but no matter what it's lagging in the UI by one draw pass. Makes no sense to me. I treid `invalidate()` on parent Views but nothing seems to force it to redraw until another `onDraw()` pass which is every 60 seconds in ambient mode.