### PR TITLE
closes #681 tell {N} to invalidate date-time cache so that when we ge…

### DIFF
--- a/apps/wear/smartdrive/app/package.json
+++ b/apps/wear/smartdrive/app/package.json
@@ -1,6 +1,7 @@
 {
   "main": "app.js",
   "android": {
+    "handleTimeZoneChanges": true,
     "v8Flags": "--nolazy --expose_gc",
     "markingMode": "none",
     "codeCache": "true",


### PR DESCRIPTION
…t a "new Date()" after a timezone update we get time for the correct timezone.