### PR TITLE
Closes #732

### DIFF
--- a/apps/wear/pushtracker/app/pages/main-page/main-view-model.ts
+++ b/apps/wear/pushtracker/app/pages/main-page/main-view-model.ts
@@ -597,7 +597,11 @@ export class MainViewModel extends Observable {
       const context = application.android.context;
       intent.setClassName(context, 'com.permobil.pushtracker.ActivityService');
       intent.setAction('ACTION_START_SERVICE');
-      context.startService(intent);
+      // The startService() method now throws an IllegalStateException if an app targeting Android 8.0 tries to use that method in a situation when it isn't permitted to create background services.
+      // We target 26+ so changing this to call the `startForegroundService` method should resolve this from throwing.
+      // @link - https://sentry.io/organizations/maxmobility/issues/1135637410/?project=1485857&referrer=github_integration
+      // @link - https://developer.android.com/about/versions/oreo/android-8.0-changes.html#back-all
+      context.startForegroundService(intent);
       sentryBreadCrumb('Activity Service started.');
     } catch (err) {
       Sentry.captureException(err);


### PR DESCRIPTION
https://developer.android.com/about/versions/oreo/android-8.0-changes.html#back-all

Just change to use `startForegroundService` the `ActivityService being called already executes the `startForeground` method when it's started. This should resolve this `IllegalStateException` from throwing in the future.