### PR TITLE
closes #759 move init of debouncedCloseModal to constructor so that i…

### DIFF
--- a/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
@@ -307,7 +307,7 @@ export class MainViewModel extends Observable {
           title: L('warnings.title.notice'),
           message: `${L('settings.paired-to-smartdrive')}\n\n${
             this.smartDrive.address
-          }`,
+            }`,
           okButtonText: L('buttons.ok')
         });
       }
@@ -848,7 +848,7 @@ export class MainViewModel extends Observable {
         okButtonText: L('buttons.ok')
       });
       try {
-        await requestPermissions(neededPermissions, () => {});
+        await requestPermissions(neededPermissions, () => { });
         // now that we have permissions go ahead and save the serial number
         this._updateSerialNumber();
       } catch (permissionsObj) {
@@ -1135,13 +1135,15 @@ export class MainViewModel extends Observable {
     application.on(application.suspendEvent, async () => {
       sentryBreadCrumb('*** appSuspend ***');
 
+      // ensure power assist is turned off if it is on
+      this._fullStop();
+
       if (updatesViewModel) {
         sentryBreadCrumb('Stopping OTA updates');
         await updatesViewModel.stopUpdates(L('updates.canceled'), true);
         sentryBreadCrumb('OTA updates successfully stopped');
       }
 
-      this._fullStop();
       this._updateComplications();
     });
 
@@ -1982,7 +1984,7 @@ export class MainViewModel extends Observable {
       .addCategory(android.content.Intent.CATEGORY_BROWSABLE)
       .addFlags(
         android.content.Intent.FLAG_ACTIVITY_NO_HISTORY |
-          android.content.Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
+        android.content.Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
       )
       .setData(android.net.Uri.parse(playStorePrefix + packageName));
     application.android.foregroundActivity.startActivity(intent);
@@ -2047,7 +2049,7 @@ export class MainViewModel extends Observable {
     }
     intent.addFlags(
       android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK |
-        android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+      android.content.Intent.FLAG_ACTIVITY_NEW_TASK
     );
     intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NO_ANIMATION);
     application.android.foregroundActivity.startActivity(intent);


### PR DESCRIPTION
…t can be used in the stopUpdates function even if init() has not been called. added some more breadcrumbs to stopupdates and moved fullStop() to before stopping updates in appSuspend.