### PR TITLE
comments out the translation http for release fix

### DIFF
--- a/apps/wear/smartdrive/app/App_Resources/Android/app.gradle
+++ b/apps/wear/smartdrive/app/App_Resources/Android/app.gradle
@@ -37,8 +37,8 @@ android {
     applicationId = "com.permobil.smartdrive.wearos"
     minSdkVersion 26
     targetSdkVersion 28
-    versionCode 10021
-    versionName "1.0.01"
+    versionCode 10022
+    versionName "1.0.00"
 		ndk {
 			abiFilters 'armeabi-v7a', 'arm64-v8a'
 		}

--- a/apps/wear/smartdrive/app/pages/modals/settings/settings-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/modals/settings/settings-view-model.ts
@@ -1,6 +1,6 @@
 import { ApplicationSettings, Frame, knownFolders, Observable, Page, path, ShowModalOptions, ViewBase } from '@nativescript/core';
 import { getFile } from '@nativescript/core/http';
-import { Device, Log, wait } from '@permobil/core';
+import { Device, Log } from '@permobil/core';
 import { getDefaultLang, L, Prop } from '@permobil/nativescript';
 import { Sentry } from 'nativescript-sentry';
 import { WatchSettings } from '../../../models';
@@ -45,9 +45,9 @@ export class SettingsViewModel extends Observable {
 
     // when the user opens the settings we are going to download the translation files and store them if needed
     // @link - https://github.com/Max-Mobility/permobil-client/issues/658
-    wait(1000).then(() => {
-      this._downloadTranslationFiles();
-    });
+    // wait(1000).then(() => {
+    //   this._downloadTranslationFiles();
+    // });
   }
 
   onChangeSettingsItemTap(args) {


### PR DESCRIPTION
This will let us "downgrade" the release until we test the timeout on the translation download.

We don't necessarily need to merge this, but figured having something for tracking purposes of the change (release) would be good to have. Up to you @finger563, also check your email.