### PR TITLE
closes #801

### DIFF
--- a/apps/wear/smartdrive/app/app.ts
+++ b/apps/wear/smartdrive/app/app.ts
@@ -14,7 +14,7 @@ console.timeEnd('load language files');
 application.on(
   application.uncaughtErrorEvent,
   (args: application.UnhandledErrorEventData) => {
-    Sentry.captureException(args.error, {
+    Sentry.captureException(new Error(JSON.stringify(args)), {
       tags: {
         type: 'uncaughtErrorEvent'
       }
@@ -25,7 +25,7 @@ application.on(
 application.on(
   application.discardedErrorEvent,
   (args: application.DiscardedErrorEventData) => {
-    Sentry.captureException(args.error, {
+    Sentry.captureException(new Error(JSON.stringify(args)), {
       tags: {
         type: 'discardedErrorEvent'
       }

--- a/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
@@ -1173,7 +1173,7 @@ export class MainViewModel extends Observable {
       application.uncaughtErrorEvent,
       (args: application.UnhandledErrorEventData) => {
         if (args) {
-          Sentry.captureException(args.error, {
+          Sentry.captureException(new Error(JSON.stringify(args)), {
             tags: {
               type: 'uncaughtErrorEvent'
             }

--- a/apps/wear/smartdrive/app/pages/modals/settings/settings-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/modals/settings/settings-view-model.ts
@@ -229,7 +229,7 @@ export class SettingsViewModel extends Observable {
   }
 
   private _handleDownloadError(err) {
-    sentryBreadCrumb(`Error downloading files: ${err}`);
+    sentryBreadCrumb(`Error downloading files: ${JSON.stringify(err)}`);
     Sentry.captureException(err);
     alert({
       title: L('failures.title'),

--- a/apps/wear/smartdrive/app/pages/modals/updates/updates-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/modals/updates/updates-view-model.ts
@@ -172,13 +172,13 @@ export class UpdatesViewModel extends Observable {
 
     // now init the ui
     await this.init().catch(err => {
-      sentryBreadCrumb('updates init error: ' + err);
+      sentryBreadCrumb('updates init error: ' + JSON.stringify(err));
       Sentry.captureException(err);
     });
 
     // now check for updates
     await this.checkForUpdates().catch(err => {
-      sentryBreadCrumb('checkForUpdates::error: ' + err);
+      sentryBreadCrumb('checkForUpdates::error: ' + JSON.stringify(err));
     });
   }
 

--- a/apps/wear/smartdrive/app/services/kinvey.service.ts
+++ b/apps/wear/smartdrive/app/services/kinvey.service.ts
@@ -81,7 +81,9 @@ export class SmartDriveKinveyService extends KinveyService {
       response = await this.getFile(undefined, query);
       return response;
     } catch (err) {
-      throw new Error(`Error downloading translation files: ${err}`);
+      throw new Error(
+        `Error downloading translation files: ${JSON.stringify(err)}`
+      );
     }
   }
 }


### PR DESCRIPTION
This should cover all SD.W cases where we were logging breadcrumbs or exceptions with potential objects and not strings which ended up giving us `[object Object]` in the logs.

Need to test this out and see if logs are improved from this to handle the various scenarios related but should be okay. 

