### PR TITLE
closes #804

### DIFF
--- a/apps/wear/smartdrive/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/apps/wear/smartdrive/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -61,11 +61,11 @@
         <meta-data
             android:name="android.support.wearable.complications.SAFE_WATCH_FACES"
             android:value="
-          com.permobil.smartdrive.watchface/com.permobil.smartdrive.watchface.DigitalWatchFaceService" />
+          com.permobil.smartdrive.wearos.watchface/com.permobil.smartdrive.wearos.watchface.DigitalWatchFaceService" />
 
         <!-- for main activity -->
         <activity
-            android:name="com.permobil.smartdrive.MainActivity"
+            android:name="com.permobil.smartdrive.wearos.MainActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/title_activity_kimera"
             android:launchMode="singleInstance"

--- a/apps/wear/smartdrive/app/App_Resources/Android/src/main/resources/sentry.properties
+++ b/apps/wear/smartdrive/app/App_Resources/Android/src/main/resources/sentry.properties
@@ -1,4 +1,4 @@
 dsn=https://05c1eee222644fd48bcd14a2845a6b6f@sentry.io/1827119
-stacktrace.app.packages=com.permobil.smartdrivemx2digital
+stacktrace.app.packages=com.permobil.smartdrive.wearos
 buffer.size=30
 buffer.flushtime=600000

--- a/apps/wear/smartdrive/app/main-activity.ts
+++ b/apps/wear/smartdrive/app/main-activity.ts
@@ -1,7 +1,7 @@
 import * as application from '@nativescript/core/application';
 import { AndroidActivityCallbacks, setActivityCallbacks } from '@nativescript/core/ui/frame';
 
-@JavaProxy('com.permobil.smartdrive.MainActivity')
+@JavaProxy('com.permobil.smartdrive.wearos.MainActivity')
 @Interfaces([androidx.wear.ambient.AmbientModeSupport.AmbientCallbackProvider])
 class MainActivity extends androidx.appcompat.app.AppCompatActivity
   implements androidx.wear.ambient.AmbientModeSupport.AmbientCallbackProvider {


### PR DESCRIPTION
Renamed the full path for the main activity which should close #804 which correctly gets the activity events firing so we can use this to close #794 