### PR TITLE
Closes #794

### DIFF
--- a/apps/wear/smartdrive/app/utils/utils.ts
+++ b/apps/wear/smartdrive/app/utils/utils.ts
@@ -6,6 +6,10 @@ import { WearOsLayout } from 'nativescript-wear-os';
 
 declare const com: any;
 
+export function _isActivityThis(activity: any) {
+  return `${activity}`.includes(application.android.packageName);
+}
+
 export function isNetworkAvailable(minBandwidthKbps?: number) {
   let isAvailable = false;
   const networkManager = application.android.context.getSystemService(


### PR DESCRIPTION
- Adds back the alert if the user has denied bluetooth permission so they know to enable it to use functionality.
- Closes #794 to prevent downloading files every time the screen resumes from being stopped/screen time out (always-on disabled) when on settings screen.