### PR TITLE
bugfixes and updates to smartdrive state management and wireless upda…

### DIFF
--- a/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
@@ -338,7 +338,7 @@ export class MainViewModel extends Observable {
           title: L('warnings.title.notice'),
           message: `${L('settings.paired-to-smartdrive')}\n\n${
             this.smartDrive.address
-          }`,
+            }`,
           okButtonText: L('buttons.ok')
         });
       }
@@ -1055,27 +1055,15 @@ export class MainViewModel extends Observable {
     if (this.smartDrive === undefined || this.smartDrive === null) {
       return;
     }
-    sentryBreadCrumb('Loading SD state from LS');
-    const savedSd = LS.getItem(
-      'com.permobil.smartdrive.wearos.smartdrive.data'
-    );
-    if (savedSd) {
-      this.smartDrive.fromObject(savedSd);
-    }
+    this.smartDrive.loadStateFromLS();
     // update the displayed smartdrive data
     this.smartDriveCurrentBatteryPercentage =
       (this.smartDrive && this.smartDrive.battery) || 0;
   }
 
   private _saveSmartDriveStateToLS() {
-    sentryBreadCrumb('Saving SD state to LS');
     if (this.smartDrive) {
-      LS.setItemObject(
-        'com.permobil.smartdrive.wearos.smartdrive.data',
-        this.smartDrive.data()
-      );
-      // save the updated smartdrive battery
-      appSettings.setNumber(DataKeys.SD_BATTERY, this.smartDrive.battery);
+      this.smartDrive.saveStateToLS();
     } else {
       // make sure we have 0 battery saved
       appSettings.setNumber(DataKeys.SD_BATTERY, 0);
@@ -2028,7 +2016,7 @@ export class MainViewModel extends Observable {
       .addCategory(android.content.Intent.CATEGORY_BROWSABLE)
       .addFlags(
         android.content.Intent.FLAG_ACTIVITY_NO_HISTORY |
-          android.content.Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
+        android.content.Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
       )
       .setData(android.net.Uri.parse(playStorePrefix + packageName));
     application.android.foregroundActivity.startActivity(intent);
@@ -2093,7 +2081,7 @@ export class MainViewModel extends Observable {
     }
     intent.addFlags(
       android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK |
-        android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+      android.content.Intent.FLAG_ACTIVITY_NEW_TASK
     );
     intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NO_ANIMATION);
     application.android.foregroundActivity.startActivity(intent);

--- a/apps/wear/smartdrive/app/pages/modals/updates/updates-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/modals/updates/updates-view-model.ts
@@ -268,9 +268,13 @@ export class UpdatesViewModel extends Observable {
 
   async getSmartDriveVersion() {
     return new Promise((resolve, reject) => {
+      sentryBreadCrumb('getting smartdrive version');
       if (this.smartDrive && this.smartDrive.hasVersionInfo()) {
         // if we've already talked to this SD and gotten its
         // version info then we can just resolve
+        sentryBreadCrumb('Already have smartdrive version:' +
+          '\n\tmcu: ' + this.smartDrive.mcu_version_string +
+          '\n\tble: ' + this.smartDrive.ble_version_string);
         resolve(true);
         return;
       } else {
@@ -291,6 +295,9 @@ export class UpdatesViewModel extends Observable {
         const onVersion = () => {
           remove();
           clearTimeout(connectTimeoutId);
+          sentryBreadCrumb('Got smartdrive version:' +
+            '\n\tmcu: ' + this.smartDrive.mcu_version_string +
+            '\n\tble: ' + this.smartDrive.ble_version_string);
           resolve();
         };
         this.smartDrive.on(SmartDrive.smartdrive_mcu_version_event, onVersion);
@@ -388,6 +395,8 @@ export class UpdatesViewModel extends Observable {
     this.unregisterForSmartDriveEvents();
     if (this.smartDrive) {
       this.smartDrive.cancelOTA();
+      sentryBreadCrumb('Updating saved SD state');
+      this.smartDrive.saveStateToLS();
     }
     this.unregisterForTimeUpdates();
     this._closeCallback();
@@ -455,7 +464,9 @@ export class UpdatesViewModel extends Observable {
         );
       }
     }
-
+    if (state !== this.smartDriveOtaState) {
+      sentryBreadCrumb('SmartDrive OTA Status, new state: ' + state);
+    }
     this.smartDriveOtaState = state;
   }
 
@@ -564,7 +575,6 @@ export class UpdatesViewModel extends Observable {
     // Now let's connect to the SD to make sure that we get it's
     // version information
     try {
-      sentryBreadCrumb('getting smartdrive version');
       await this.getSmartDriveVersion();
     } catch (err) {
       sentryBreadCrumb('Connecting to smartdrive failed');
@@ -573,7 +583,7 @@ export class UpdatesViewModel extends Observable {
     // Now perform the SmartDrive updates if we need to
 
     // now see what we need to do with the data
-    sentryBreadCrumb('Finished downloading updates.');
+    sentryBreadCrumb('Finished checking for updates');
     this.performSmartDriveWirelessUpdate();
   }
 
@@ -594,55 +604,72 @@ export class UpdatesViewModel extends Observable {
     const version = SmartDriveData.Firmwares.versionByteToString(
       Math.max(mcuVersion, bleVersion)
     );
-    sentryBreadCrumb('got version: ' + version);
-    // show dialog to user informing them of the version number and changes
-    const changes = Object.keys(this.currentVersions).map(
-      k => this.currentVersions[k].changes
-    );
-    // Log.D('got changes', changes);
-    await alert({
-      title: L('updates.version') + ' ' + version,
-      message: L('updates.changes') + '\n\n' + flatten(changes).join('\n\n'),
-      okButtonText: L('buttons.ok')
-    });
-    sentryBreadCrumb('Beginning SmartDrive update');
-
-    const bleFw = new Uint8Array(
-      this.currentVersions['SmartDriveBLE.ota'].data
-    );
-    const mcuFw = new Uint8Array(
-      this.currentVersions['SmartDriveMCU.ota'].data
-    );
-    sentryBreadCrumb(`mcu length: ${mcuFw.length}`);
-    sentryBreadCrumb(`ble length: ${bleFw.length}`);
-    // maintain CPU resources while updating
-    this.maintainCPU();
-    // smartdrive needs to update
-    let otaStatus = '';
-    try {
-      this._otaStarted = true;
-      otaStatus = await this.smartDrive.performOTA(
-        bleFw,
-        mcuFw,
-        bleVersion,
-        mcuVersion,
-        300 * 1000
+    const versionString = [mcuVersion, bleVersion].map(SmartDriveData.Firmwares.versionByteToString).join(', ');
+    sentryBreadCrumb('got curent firmware versions: ' + versionString);
+    // do we need to update?
+    const isUpToDate = this.smartDrive.isMcuUpToDate(mcuVersion) &&
+      this.smartDrive.isBleUpToDate(bleVersion);
+    if (isUpToDate) {
+      this.smartDriveOtaState = L('updates.up-to-date');
+      // let the user know early if they are already up to date!
+      await alert({
+        title: L('updates.status'),
+        message: L('updates.up-to-date'),
+        okButtonText: L('buttons.ok')
+      });
+      // now close the updates page
+      this.closeModal();
+    } else {
+      // show dialog to user informing them of the version number and changes
+      const changes = Object.keys(this.currentVersions).map(
+        k => this.currentVersions[k].changes
       );
-      this._otaStarted = false;
-      sentryBreadCrumb('"' + otaStatus + '" ' + typeof otaStatus);
-      if (otaStatus === 'updates.canceled') {
-        this.smartDriveOtaActions.splice(0, this.smartDriveOtaActions.length, {
-          label: L('ota.action.close'),
-          func: this._debouncedCloseModal.bind(this),
-          action: 'ota.action.close',
-          class: 'action-close'
-        });
+      // Log.D('got changes', changes);
+      await alert({
+        title: L('updates.version') + ' ' + version,
+        message: L('updates.changes') + '\n\n' + flatten(changes).join('\n\n'),
+        okButtonText: L('buttons.ok')
+      });
+      sentryBreadCrumb('Beginning SmartDrive update');
+
+      const bleFw = new Uint8Array(
+        this.currentVersions['SmartDriveBLE.ota'].data
+      );
+      const mcuFw = new Uint8Array(
+        this.currentVersions['SmartDriveMCU.ota'].data
+      );
+      sentryBreadCrumb(`mcu length: ${mcuFw.length}`);
+      sentryBreadCrumb(`ble length: ${bleFw.length}`);
+      // maintain CPU resources while updating
+      this.maintainCPU();
+      // smartdrive needs to update
+      let otaStatus = '';
+      try {
+        this._otaStarted = true;
+        this.registerForSmartDriveEvents();
+        otaStatus = await this.smartDrive.performOTA(
+          bleFw,
+          mcuFw,
+          bleVersion,
+          mcuVersion,
+          300 * 1000
+        );
+        this._otaStarted = false;
+        sentryBreadCrumb('ota status at end: "' + otaStatus + '" type=' + typeof otaStatus);
+        if (otaStatus === 'updates.canceled') {
+          this.smartDriveOtaActions.splice(0, this.smartDriveOtaActions.length, {
+            label: L('ota.action.close'),
+            func: this._debouncedCloseModal.bind(this),
+            action: 'ota.action.close',
+            class: 'action-close'
+          });
+        }
+      } catch (err) {
+        return this.updateError(err, L('updates.failed'), `${err}`);
       }
-    } catch (err) {
-      return this.updateError(err, L('updates.failed'), `${err}`);
+      const updateMsg = L(otaStatus);
+      await this.stopUpdates(updateMsg, false);
     }
-    const updateMsg = L(otaStatus);
-    await this.stopUpdates(updateMsg, false);
   }
 
   async updateFirmwareData(f: any) {


### PR DESCRIPTION
…tes. Make sure wireless updates saves smartdrive state when closing so that users will not erroneously think their smartdrive is not up to date in very specific situations. move smartdrive state loading / saving to LS and appSettings into smartdrive class so that main-view-model and updates-view-model can both use them. fix some edge-case logic errors in smartdrive::performOTA function which prevented the update from running in some cases (erroneously completing without doing anything) and which erroneously indicated failure even when there was success. Quickly return and inform the user if their smartdrive is up to date so they do not have to press any more buttons or inadvertently think their smartdrive is out of date. updated breadcrumbs in wireless updates page so that we have more info in sentry about what ota state the watch / smartdrive is in if it crashes.

WIP #820 