### PR TITLE
Update how we measure battery usage in MX2+ app;

### DIFF
--- a/apps/wear/smartdrive/app/namespaces/smartdrive-data.ts
+++ b/apps/wear/smartdrive/app/namespaces/smartdrive-data.ts
@@ -72,10 +72,10 @@ export namespace SmartDriveData {
     ) {
       const timestamp = SmartDriveData.Info.getHalfHourDate().getTime();
       return {
-        [SmartDriveData.Info.BatteryName]: battery,
-        [SmartDriveData.Info.CoastDistanceName]: coast,
-        [SmartDriveData.Info.DriveDistanceName]: drive,
-        [SmartDriveData.Info.StartTimeName]: timestamp
+        [SmartDriveData.Info.BatteryName]: +battery,
+        [SmartDriveData.Info.CoastDistanceName]: +coast,
+        [SmartDriveData.Info.DriveDistanceName]: +drive,
+        [SmartDriveData.Info.StartTimeName]: +timestamp
       };
     }
 
@@ -101,7 +101,8 @@ export namespace SmartDriveData {
       if (records && records.length) {
         // determine if we need a new record
         const record = records[records.length - 1];
-        const timeDiffMs = timeMs - record[SmartDriveData.Info.StartTimeName];
+        const recordTimeMs = +record[SmartDriveData.Info.StartTimeName] || 0;
+        const timeDiffMs = timeMs - recordTimeMs;
         if (timeDiffMs > SmartDriveData.Info.RECORD_LENGTH_MS) {
           // we need a new record
           const record = SmartDriveData.Info.makeRecord(
@@ -112,12 +113,14 @@ export namespace SmartDriveData {
           // now append it
           records.push(record);
         } else {
+          const currentBattery = +record[SmartDriveData.Info.BatteryName] || 0;
+          const updatedBattery = battery + currentBattery;
           // can just update this record
-          record[SmartDriveData.Info.BatteryName] += battery;
+          record[SmartDriveData.Info.BatteryName] = +updatedBattery;
           record[SmartDriveData.Info.CoastDistanceName] =
-            coastDistance || record[SmartDriveData.Info.CoastDistanceName];
+            +coastDistance || +record[SmartDriveData.Info.CoastDistanceName];
           record[SmartDriveData.Info.DriveDistanceName] =
-            driveDistance || record[SmartDriveData.Info.DriveDistanceName];
+            +driveDistance || +record[SmartDriveData.Info.DriveDistanceName];
         }
       } else {
         // we have no records, make a new one
@@ -148,7 +151,8 @@ export namespace SmartDriveData {
         return null;
       }
       // compute updates
-      const updatedBattery = battery + info[SmartDriveData.Info.BatteryName];
+      const currentBattery = +info[SmartDriveData.Info.BatteryName] || 0;
+      const updatedBattery = battery + currentBattery;
       const updatedDriveDistance =
         driveDistance || info[SmartDriveData.Info.DriveDistanceName];
       const updatedCoastDistance =
@@ -171,9 +175,9 @@ export namespace SmartDriveData {
       }
       // now return the updates
       return {
-        [SmartDriveData.Info.BatteryName]: updatedBattery,
-        [SmartDriveData.Info.DriveDistanceName]: updatedDriveDistance,
-        [SmartDriveData.Info.CoastDistanceName]: updatedCoastDistance,
+        [SmartDriveData.Info.BatteryName]: +updatedBattery,
+        [SmartDriveData.Info.DriveDistanceName]: +updatedDriveDistance,
+        [SmartDriveData.Info.CoastDistanceName]: +updatedCoastDistance,
         [SmartDriveData.Info.RecordsName]: recordString,
         [SmartDriveData.Info.HasBeenSentName]: 0
       };

--- a/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
@@ -2614,7 +2614,7 @@ export class MainViewModel extends Observable {
 
   private async _updateTodaysUsageInfo(updates: any) {
     if (!this._todaysUsage) {
-      Log.E("_updateTodaysUsageInfo called but we have no _todaysUsageObject!");
+      Log.E('_updateTodaysUsageInfo called but we have no _todaysUsageObject!');
       return;
     }
     // update the data stored in SQLite

--- a/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
@@ -2525,17 +2525,12 @@ export class MainViewModel extends Observable {
         // has been used. we directly overwrite the distance and
         // update the records
         const updates = SmartDriveData.Info.updateInfo(args, u);
-        await this._sqliteService.updateInTable(
-          SmartDriveData.Info.TableName,
-          updates,
-          {
-            [SmartDriveData.Info.IdName]: u.id
-          }
-        );
+        await this._updateTodaysUsageInfo(updates);
       } else {
-        // should not come here - _getTodaysUsageFromDatabase loads /
-        // creates as needed - but if it encounters an exception then
-        // it will not have an id - so we will try to make it again...
+        // should not come here - _getTodaysUsageInfoFromDatabase
+        // loads / creates as needed - but if it encounters an
+        // exception then it will not have an id - so we will try to
+        // make it again...
         this._todaysUsage = await this._makeTodaysUsage(
           battery,
           driveDistance,
@@ -2615,6 +2610,26 @@ export class MainViewModel extends Observable {
       }
     }
     return this._todaysUsage;
+  }
+
+  private async _updateTodaysUsageInfo(updates: any) {
+    if (!this._todaysUsage) {
+      Log.E("_updateTodaysUsageInfo called but we have no _todaysUsageObject!");
+      return;
+    }
+    // update the data stored in SQLite
+    const _id = this._todaysUsage[SmartDriveData.Info.IdName];
+    await this._sqliteService.updateInTable(
+      SmartDriveData.Info.TableName,
+      updates,
+      {
+        [SmartDriveData.Info.IdName]: _id
+      }
+    );
+    // now update _todaysUsage variable
+    Object.keys(updates).forEach((k) => {
+      this._todaysUsage[k] = updates[k];
+    });
   }
 
   private async _updateSharedUsageInfo(sdData: any[]) {


### PR DESCRIPTION
Fixed bug where _todaysUsage was not updated when inserting updates into SQLite table in _saveSmartDriveData(...) so it constantly over-wrote / invalidated data. Ensure all data values when computing updates are proper numbers (no NaNs) for better comparison and addition. Properly update _todaysUsage when writing updates to SQLite table for todays data.