### PR TITLE
Feature/337 prompt user to connect sd on setting change

### DIFF
--- a/apps/wear/smartdrive/app/assets/i18n/en.json
+++ b/apps/wear/smartdrive/app/assets/i18n/en.json
@@ -269,6 +269,7 @@
     },
     "scanning": "Scanning for SmartDrive to pair with...",
     "select-smartdrive": "Select SmartDrive",
+    "send-settings-prompt": "The new settings will not take effect until the next time you turn Power Assist On and connect to the SmartDrive. Would you like to turn power assist on now to connect to the SmartDrive and update its settings?",
     "set-time": "Date & Time",
     "syncing-with-server": "Synchronizing with server...",
     "tap-sensitivity": "Tap Sensitivity",

--- a/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/main-page/main-view-model.ts
@@ -366,7 +366,7 @@ export class MainViewModel extends Observable {
           title: L('warnings.title.notice'),
           message: `${L('settings.paired-to-smartdrive')}\n\n${
             this.smartDrive.address
-          }`,
+            }`,
           okButtonText: L('buttons.ok')
         });
       }
@@ -406,14 +406,31 @@ export class MainViewModel extends Observable {
         settingsService: this._settingsService,
         sdKinveyService: this._kinveyService
       },
-      closeCallback: () => {
+      closeCallback: async (shouldConnectSmartDrive: boolean) => {
         this._showingModal = false;
         // we dont do anything with the about to return anything
         // now update any display that needs settings:
         this._updateSpeedDisplay();
         this._updateChartData();
+        // see if the user changed accel, SC mode, SC max speed
+        // (according to
+        // https://github.com/Max-Mobility/permobil-client/issues/337)
+        // and ask them if they'd like to send the settings now
+        if (shouldConnectSmartDrive) {
+          const turnPowerAssistOn = await Dialogs.confirm({
+            title: L('warnings.title.notice'),
+            message: L('settings.send-settings-prompt'),
+            okButtonText: L('power-assist.activate'),
+            cancelButtonText: L('buttons.dismiss'),
+            cancelable: false
+          });
+          if (turnPowerAssistOn) {
+            this.enablePowerAssist();
+          }
+        }
       },
       animated: false,
+      cancelable: false,
       fullscreen: true
     };
     this._showingModal = true;
@@ -2077,7 +2094,7 @@ export class MainViewModel extends Observable {
       .addCategory(android.content.Intent.CATEGORY_BROWSABLE)
       .addFlags(
         android.content.Intent.FLAG_ACTIVITY_NO_HISTORY |
-          android.content.Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
+        android.content.Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
       )
       .setData(android.net.Uri.parse(playStorePrefix + packageName));
     Application.android.foregroundActivity.startActivity(intent);
@@ -2142,7 +2159,7 @@ export class MainViewModel extends Observable {
     }
     intent.addFlags(
       android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK |
-        android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+      android.content.Intent.FLAG_ACTIVITY_NEW_TASK
     );
     intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NO_ANIMATION);
     Application.android.foregroundActivity.startActivity(intent);

--- a/apps/wear/smartdrive/app/pages/modals/settings/settings-page.ts
+++ b/apps/wear/smartdrive/app/pages/modals/settings/settings-page.ts
@@ -3,23 +3,16 @@ import { Log } from '@permobil/core';
 import { SettingsService, SmartDriveKinveyService } from '../../../services';
 import { SettingsViewModel } from './settings-view-model';
 
-let closeCallback;
-
-// Closes the modal
-export function onCloseTap() {
-  closeCallback();
-}
-
 export function onShownModally(args: ShownModallyData) {
   Log.D('settings onShownModally');
   const page = args.object as Page;
   const settingsService = args.context.settingsService as SettingsService;
   const sdKinveyService = args.context
     .sdKinveyService as SmartDriveKinveyService;
-  closeCallback = args.closeCallback; // the closeCallback handles closing the modal
 
+  // the closeCallback handles closing the modal
   const data = {
-    closeCallback: args.context.closeCallback
+    closeCallback: args.closeCallback
   };
 
   page.bindingContext = new SettingsViewModel(

--- a/apps/wear/smartdrive/app/pages/modals/settings/settings-page.xml
+++ b/apps/wear/smartdrive/app/pages/modals/settings/settings-page.xml
@@ -1,4 +1,4 @@
-<Page xmlns="http://schemas.nativescript.org/tns.xsd" 
+<Page xmlns="http://schemas.nativescript.org/tns.xsd"
   xmlns:wol="nativescript-wear-os/packages/wear-os-layout" shownModally="onShownModally" actionBarHidden="true">
   <wol:WearOsLayout id="wearOsLayout" disableInsetConstraint="true" height="100%" width="100%">
     <StackLayout height="100%">
@@ -8,7 +8,7 @@
         <GridLayout rows="*, *, *, *, *, *, *, *, *, *, *, *, *" columns="auto, *" paddingBottom="{{ insetPadding }}">
           // Back
           <Label row="0" col="0" text="&#xe907;" class="bullet-list-icon" fontSize="18" fontWeight="bold" textWrap="true" />
-          <Label row="0" col="1" text="{{ L('buttons.back') }}" tap="onCloseTap" class="settings-label" textWrap="true" />
+          <Label row="0" col="1" text="{{ L('buttons.back') }}" tap="{{ close }}" class="settings-label" textWrap="true" />
           // Max Speed
           <Label row="1" col="0" text="&#xe905;" class="bullet-list-icon" textWrap="true" />
           <Label row="1" col="1" text="{{ L('settings.max-speed') }}" class="settings-label" textWrap="true" id="maxSpeed" tap="{{ onChangeSettingsItemTap }}" />

--- a/apps/wear/smartdrive/app/pages/modals/settings/settings-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/modals/settings/settings-view-model.ts
@@ -47,7 +47,7 @@ export class SettingsViewModel extends Observable {
   private _isDownloadingFiles: boolean = false;
   private _shouldDownloadFiles: boolean = true;
 
-  private _closeCallback: (boolean) => {};
+  private _closeCallback: (shouldConnect: boolean) => {};
   // if the user changes accel, SC mode, SC max speed then we should
   // connect to the smartdrive to update its settings.
   private _shouldConnectSmartDrive: boolean = false;

--- a/apps/wear/smartdrive/app/pages/modals/settings/settings-view-model.ts
+++ b/apps/wear/smartdrive/app/pages/modals/settings/settings-view-model.ts
@@ -47,6 +47,11 @@ export class SettingsViewModel extends Observable {
   private _isDownloadingFiles: boolean = false;
   private _shouldDownloadFiles: boolean = true;
 
+  private _closeCallback: (boolean) => {};
+  // if the user changes accel, SC mode, SC max speed then we should
+  // connect to the smartdrive to update its settings.
+  private _shouldConnectSmartDrive: boolean = false;
+
   constructor(
     page: Page,
     settingsService: SettingsService,
@@ -61,6 +66,7 @@ export class SettingsViewModel extends Observable {
     const res = configureLayout(wearOsLayout);
     this.chinSize = res.chinSize;
     this.insetPadding = res.insetPadding;
+    this._closeCallback = data.closeCallback;
     wearOsLayout.nativeView.setPadding(
       this.insetPadding,
       this.insetPadding,
@@ -87,6 +93,16 @@ export class SettingsViewModel extends Observable {
         this._downloadTranslationFiles();
       }
     });
+  }
+
+  close() {
+    this._closeCallback(this._shouldConnectSmartDrive);
+  }
+
+  settingRequiresSmartDriveConnection(setting: string) {
+    return setting === 'acceleration' ||
+      setting === 'switchcontrolmode' ||
+      setting === 'switchcontrolspeed';
   }
 
   onChangeSettingsItemTap(args) {
@@ -122,6 +138,7 @@ export class SettingsViewModel extends Observable {
       ) => {
         this._showingModal = false;
         if (confirmedByUser) {
+          // actually update the settings to make sure they're saved
           this._settingsService.settings.copy(_tempSettings);
           this._settingsService.switchControlSettings.copy(
             _tempSwitchControlSettings
@@ -129,6 +146,10 @@ export class SettingsViewModel extends Observable {
           this._settingsService.watchSettings.copy(_tempWatchSettings);
           this._settingsService.hasSentSettings = false;
           this._settingsService.saveSettings();
+          // keep track of whether the user has changed a setting
+          // which they should send to the smartdrive
+          this._shouldConnectSmartDrive = this._shouldConnectSmartDrive ||
+            this.settingRequiresSmartDriveConnection(this.activeSettingToChange);
           // warning / indication to the user that they've updated their settings
           if (this.activeSettingToChange === 'language') {
             Dialogs.confirm({
@@ -231,8 +252,8 @@ export class SettingsViewModel extends Observable {
       acc[_filename] = !current
         ? val
         : val._version > current._version
-        ? val
-        : current;
+          ? val
+          : current;
       return acc;
     }, {});
 


### PR DESCRIPTION
closes #337 

have settings modal track whether the setting changed requires connection to smartdrive and have it return that to the main page when it closes. disable swipe-close on settings page so the callback is always called with the right value. if the settings page closes and returns true (requires connection) alert the user and ask if they want to turn power assist on right now to send the settings.