### PR TITLE
Only use english version of language list

### DIFF
--- a/@permobil/nativescript/src/utils/i18n.util.ts
+++ b/@permobil/nativescript/src/utils/i18n.util.ts
@@ -128,7 +128,7 @@ const translateKey = (key: string, language: string = 'en') => {
     // do nothing - we have our defaults
   }
   return translated;
-}
+};
 
 const applicationResources = Application.getResources();
 applicationResources.L = L;

--- a/@permobil/nativescript/src/utils/i18n.util.ts
+++ b/@permobil/nativescript/src/utils/i18n.util.ts
@@ -120,10 +120,20 @@ const L = (...args: any[]) => {
   return translated;
 };
 
+const translateKey = (key: string, language: string = 'en') => {
+  let translated = key;
+  try {
+    translated = get(key, translations[language]) || translated;
+  } catch {
+    // do nothing - we have our defaults
+  }
+  return translated;
+}
+
 const applicationResources = Application.getResources();
 applicationResources.L = L;
 Application.setResources(applicationResources);
 // @ts-ignore
 global.L = L;
 
-export { getDefaultLang, setDefaultLang, use, load, update, L };
+export { getDefaultLang, setDefaultLang, use, load, translateKey, update, L };

--- a/apps/wear/pushtracker/app/namespaces/profile.ts
+++ b/apps/wear/pushtracker/app/namespaces/profile.ts
@@ -1,6 +1,6 @@
 import { Observable } from '@nativescript/core';
 import { mod } from '@permobil/core';
-import { L, getDefaultLang } from '@permobil/nativescript/src/utils';
+import { getDefaultLang, translateKey } from '@permobil/nativescript/src/utils';
 
 export class Profile extends Observable {
   settings = new Profile.Settings();
@@ -73,7 +73,7 @@ export namespace Profile {
 
     constructor() {
       super();
-      Profile.Settings.Languages.Options = Object.keys(L('language-list'));
+      Profile.Settings.Languages.Options = Object.keys(translateKey('language-list', 'en'));
     }
 
     getHeightDisplay(): string {

--- a/apps/wear/pushtracker/app/pages/modals/change-settings/change-settings-view-model.ts
+++ b/apps/wear/pushtracker/app/pages/modals/change-settings/change-settings-view-model.ts
@@ -14,7 +14,8 @@ import {
   L,
   Prop,
   restartAndroidApp,
-  setDefaultLang
+  setDefaultLang,
+  translateKey
 } from '@permobil/nativescript';
 import * as LS from 'nativescript-localstorage';
 import { DataKeys } from '../../../enums';
@@ -206,8 +207,9 @@ export class ChangeSettingsViewModel extends Observable {
         }
         break;
       case 'language':
-        this.changeSettingKeyValue = L(
-          `language-list.${this._settings.language.toLowerCase()}`
+        this.changeSettingKeyValue = translateKey(
+          `language-list.${this._settings.language.toLowerCase()}`,
+          'en'
         );
         break;
       default:

--- a/apps/wear/smartdrive/app/models/watch-settings.ts
+++ b/apps/wear/smartdrive/app/models/watch-settings.ts
@@ -1,5 +1,5 @@
 import { mod } from '@permobil/core/src/utils';
-import { L, getDefaultLang } from '@permobil/nativescript/src/utils';
+import { getDefaultLang, translateKey } from '@permobil/nativescript/src/utils';
 
 type TranslateFunction = (translationKey: string) => string;
 
@@ -23,7 +23,7 @@ export class WatchSettings {
   language: string = WatchSettings.Defaults.language;
 
   constructor() {
-    WatchSettings.Languages.Options = Object.keys(L('language-list'));
+    WatchSettings.Languages.Options = Object.keys(translateKey('language-list', 'en'));
   }
 
   toObj(): any {
@@ -98,7 +98,7 @@ export class WatchSettings {
             break;
           case 'language':
             translationKey = `language-list.${this.language.toLowerCase()}`;
-            displayString = TRANSLATE(translationKey);
+            displayString = translateKey(translationKey, 'en');
             break;
           default:
             break;


### PR DESCRIPTION
Ensures that it's always corret. Added a new `translateKey( key: string, language: string = 'en' )` function to `i18n` utils allowing us to directly specify the language to use.