### PR TITLE
fix: (PT.M) updates animated-circle dep

### DIFF
--- a/apps/mobile/pushtracker/package.json
+++ b/apps/mobile/pushtracker/package.json
@@ -11,7 +11,7 @@
     "@angular/router": "~10.1.0",
     "@maxmobility/nativescript-wear-os-comms": "file:../../../@permobil/nativescript/src/plugins/nativescript-wear-os-comms/wear-os-comms-2.0.0.tgz",
     "@maxmobility/private-keys": "autochair/maxmobility-private-keys#master",
-    "@nativescript/animated-circle": "~1.1.4",
+    "@nativescript/animated-circle": "~1.1.5",
     "@nativescript/core": "~7.0.12",
     "@nativescript/angular": "~10.1.7",
     "@nativescript/appversion": "~2.0.0",

--- a/apps/wear/pushtracker/package.json
+++ b/apps/wear/pushtracker/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@maxmobility/nativescript-wear-os-comms": "file:../../../@permobil/nativescript/src/plugins/nativescript-wear-os-comms/wear-os-comms-2.0.0.tgz",
     "@maxmobility/private-keys": "github:autochair/maxmobility-private-keys#master",
-    "@nativescript/animated-circle": "~1.1.0",
+    "@nativescript/animated-circle": "~1.1.5",
     "@nativescript/appavailability": "2.0.0",
     "@nativescript/auto-fit-text": "~1.0.1",
     "@nativescript/core": "file:../../../forked-plugins/nativescript-core-7.0.3.tgz",

--- a/apps/wear/smartdrive/package.json
+++ b/apps/wear/smartdrive/package.json
@@ -9,7 +9,7 @@
     "@maxmobility/nativescript-wear-os-comms": "file:../../../@permobil/nativescript/src/plugins/nativescript-wear-os-comms/wear-os-comms-2.0.0.tgz",
     "@maxmobility/private-keys": "github:autochair/maxmobility-private-keys#master",
     "@nativescript-community/ui-material-ripple": "~4.0.11",
-    "@nativescript/animated-circle": "~1.1.0",
+    "@nativescript/animated-circle": "~1.1.5",
     "@nativescript/appavailability": "~2.0.0",
     "@nativescript/auto-fit-text": "~1.0.1",
     "@nativescript/core": "file:../../../forked-plugins/nativescript-core-7.0.3.tgz",


### PR DESCRIPTION
This fixes the iOS boolean value setting crash occurring with the iOS V8 runtime.

https://github.com/NativeScript/ns-v8ios-runtime/issues/76

closes #893 