### PR TITLE
fix: (PT.M) theme change not working

### DIFF
--- a/apps/mobile/pushtracker/package.json
+++ b/apps/mobile/pushtracker/package.json
@@ -12,7 +12,7 @@
     "@maxmobility/nativescript-wear-os-comms": "file:../../../@permobil/nativescript/src/plugins/nativescript-wear-os-comms/wear-os-comms-2.0.0.tgz",
     "@maxmobility/private-keys": "autochair/maxmobility-private-keys#master",
     "@nativescript/animated-circle": "~1.1.5",
-    "@nativescript/core": "~7.0.12",
+    "@nativescript/core": "~7.0.13",
     "@nativescript/angular": "~10.1.7",
     "@nativescript/appversion": "~2.0.0",
     "@nativescript/datetimepicker": "~2.0.4",

--- a/apps/mobile/pushtracker/src/app/utils/themes-utils.ts
+++ b/apps/mobile/pushtracker/src/app/utils/themes-utils.ts
@@ -24,7 +24,7 @@ export function applyTheme(newTheme: string) {
 
 export function enableDarkTheme() {
   themes.applyThemeCss(
-    require('../scss/theme-dark.scss').toString(),
+    require('../scss/theme-dark.scss').default.toString(),
     'theme-dark.scss'
   );
   clearLightStatusBar();
@@ -44,7 +44,7 @@ export function enableDarkTheme() {
 
 export function enableDefaultTheme() {
   themes.applyThemeCss(
-    require('../scss/theme-default.scss').toString(),
+    require('../scss/theme-default.scss').default.toString(),
     'theme-default.scss'
   );
   setLightStatusBar();

--- a/apps/mobile/pushtracker/src/main.ts
+++ b/apps/mobile/pushtracker/src/main.ts
@@ -34,12 +34,12 @@ const SAVED_THEME = ApplicationSettings.getString(
 );
 if (SAVED_THEME === APP_THEMES.DEFAULT) {
   themes.applyThemeCss(
-    require('./app/scss/theme-default.scss').toString(),
+    require('./app/scss/theme-default.scss').default.toString(),
     'theme-default.scss'
   );
 } else if (SAVED_THEME === APP_THEMES.DARK) {
   themes.applyThemeCss(
-    require('./app/scss/theme-dark.scss').toString(),
+    require('./app/scss/theme-dark.scss').default.toString(),
     'theme-dark.scss'
   );
 }


### PR DESCRIPTION
Fixes the theme switching and theme application on app start/resume.

The ES2017 switch impacts the `require()` statement inside the TS file. So it was ending up as `[object Module]` being required as the scss file to apply at runtime. Instead of valid css. Adding `.default.toString()` on the `require()` is the fix to actually get the raw css.