### PR TITLE
feat: (PT.M) handle unknown host during login

### DIFF
--- a/apps/mobile/pushtracker/src/app/modules/login/login.component.ts
+++ b/apps/mobile/pushtracker/src/app/modules/login/login.component.ts
@@ -11,7 +11,8 @@ import {
   Page,
   PercentLength,
   TextField,
-  View
+  View,
+  Dialogs
 } from '@nativescript/core';
 import { TranslateService } from '@ngx-translate/core';
 import { LoadingIndicator } from '@nstudio/nativescript-loading-indicator';
@@ -154,8 +155,18 @@ export class LoginComponent implements OnInit {
           duration: ToastDuration.SHORT,
           position: ToastPosition.CENTER
         }).show();
+      } else if (error.toString().includes('UnknownHostException')) {
+        this._logService.logBreadCrumb(
+          LoginComponent.name,
+          'UnknownHostException thrown. Most likely a poor internet conntection.'
+        );
+        new Toasty({
+          text: this._translateService.instant('general.sign-in-error-3'),
+          duration: ToastDuration.SHORT,
+          position: ToastPosition.CENTER
+        }).show();
       } else {
-        alert({
+        Dialogs.alert({
           title: this._translateService.instant('general.error'),
           message: this._translateService.instant('general.sign-in-error-1'),
           okButtonText: this._translateService.instant('general.ok')


### PR DESCRIPTION
Encountered this while working on hotspot. Knew we had these in the sentry logs and it doesn't seem like we should be logging this typically. As we know the host is definitely there (kinvey). So this seems better than throwing an exception on our end to sentry, just informing the user to check their internet connection as it's usually related to that (or timeout which again indicates a really slow internet connection).